### PR TITLE
 HAAR-3650: add missing db secrets config

### DIFF
--- a/docker-compose-local-postgres.yml
+++ b/docker-compose-local-postgres.yml
@@ -5,14 +5,14 @@ services:
     image: postgres:15
     networks:
       - hmpps
-    container_name: sar-html-renderer-db
+    container_name: sar-db
     restart: always
     ports:
       - "5432:5432"
     environment:
       - POSTGRES_PASSWORD=admin_password
       - POSTGRES_USER=admin
-      - POSTGRES_DB=sar-html-renderer-db
+      - POSTGRES_DB=sar-db
 
 networks:
   hmpps:

--- a/helm_deploy/hmpps-subject-access-request-html-renderer/values.yaml
+++ b/helm_deploy/hmpps-subject-access-request-html-renderer/values.yaml
@@ -26,15 +26,18 @@ generic-service:
   #     [name of environment variable as seen by app]: [key of kubernetes secret to load]
 
   namespace_secrets:
-    hmpps-subject-access-request-html-renderer-client-creds:
-      # Example client registration secrets
-      EXAMPLE_API_CLIENT_ID: "API_CLIENT_ID"
-      EXAMPLE_API_CLIENT_SECRET: "API_CLIENT_SECRET"
     hmpps-subject-access-request-html-renderer:
       SYSTEM_CLIENT_ID: "SYSTEM_CLIENT_ID"
       SYSTEM_CLIENT_SECRET: "SYSTEM_CLIENT_SECRET"
+
     hmpps-subject-access-request-html-renderer-application-insights:
       APPLICATIONINSIGHTS_CONNECTION_STRING: "APPLICATIONINSIGHTS_CONNECTION_STRING"
+
+    rds-instance-output:
+      DATABASE_ENDPOINT: "rds_instance_endpoint"
+      DATABASE_NAME: "database_name"
+      DATABASE_USERNAME: "database_username"
+      DATABASE_PASSWORD: "database_password"
 
   allowlist:
     groups:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/controller/TemplateTestController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/controller/TemplateTestController.kt
@@ -42,7 +42,7 @@ class TemplateTestController(
       ),
     ],
   )
-  fun test(@RequestBody renderReq: DeveloperRenderRequest): ResponseEntity<String> {
+  fun renderTemplate(@RequestBody renderReq: DeveloperRenderRequest): ResponseEntity<String> {
     val html = renderService.renderServiceDataHtmlForDev(renderReq.serviceName!!, renderReq.data!!)
     return ResponseEntity<String>(html, null, HttpStatus.OK)
   }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -3,13 +3,13 @@ hmpps-auth:
 
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/sar-html-renderer-db?sslmode=prefer
+    url: jdbc:postgresql://localhost:5432/sar-db?sslmode=prefer
     username: admin
     password: admin_password
   flyway:
     locations: classpath:db/sar,db/sar_{vendor},db/dev/data/sar
     enabled: true
-    url: jdbc:postgresql://localhost:5432/sar-html-renderer-db?sslmode=prefer
+    url: jdbc:postgresql://localhost:5432/sar-db?sslmode=prefer
     user: admin
     password: admin_password
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -15,7 +15,7 @@ web-client:
 
 spring:
   datasource:
-    url: 'jdbc:h2:mem:subject-access-request-db;MODE=PostgreSQL'
+    url: 'jdbc:h2:mem:sar-db;MODE=PostgreSQL'
     username: sa
     password:
   flyway:


### PR DESCRIPTION
Added missing namespace secrets for DB connection. Service will use the existing worker DB for the purposes of the spike work. This can be changed later if necessary.,