### PR TITLE
HAAR-3650: updated render endpoint to return 204 when document already exists

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/controller/RenderTemplateController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/controller/RenderTemplateController.kt
@@ -50,14 +50,19 @@ class RenderTemplateController(private val renderService: RenderService) {
   suspend fun renderTemplate(@RequestBody renderRequest: RenderRequest): ResponseEntity<RenderResponse> {
     log.info("Rendering HTML for subject access request: $renderRequest")
 
-    renderService.renderServiceDataHtml(renderRequest)
+    val renderResult = renderService.renderServiceDataHtml(renderRequest)
+
+    val status = when (renderResult) {
+      RenderService.RenderResult.CREATED -> HttpStatus.CREATED
+      RenderService.RenderResult.DATA_ALREADY_EXISTS -> HttpStatus.NO_CONTENT
+    }
 
     return ResponseEntity(
       RenderResponse(
         renderRequest.id!!,
         renderRequest.serviceName!!,
       ),
-      HttpStatus.CREATED,
+      status,
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/controller/RenderTemplateController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/controller/RenderTemplateController.kt
@@ -16,6 +16,8 @@ import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.controller.entity.RenderRequest
 import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.controller.entity.RenderResponse
 import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.service.RenderService
+import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.service.RenderService.RenderResult.CREATED
+import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.service.RenderService.RenderResult.DATA_ALREADY_EXISTS
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 @RestController
@@ -33,7 +35,11 @@ class RenderTemplateController(private val renderService: RenderService) {
     description = "Endpoint renders a subject access request HTML report fragment",
     security = [SecurityRequirement(name = "subject-access-request-html-renderer-ui-role")],
     responses = [
-      ApiResponse(responseCode = "201", description = "Template fragment created successfully"),
+      ApiResponse(
+        responseCode = "201",
+        description = "Template fragment created successfully",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = RenderResponse::class))],
+      ),
       ApiResponse(responseCode = "204", description = "Cached template fragment exists no action required"),
       ApiResponse(
         responseCode = "401",
@@ -50,19 +56,21 @@ class RenderTemplateController(private val renderService: RenderService) {
   suspend fun renderTemplate(@RequestBody renderRequest: RenderRequest): ResponseEntity<RenderResponse> {
     log.info("Rendering HTML for subject access request: $renderRequest")
 
-    val renderResult = renderService.renderServiceDataHtml(renderRequest)
-
-    val status = when (renderResult) {
-      RenderService.RenderResult.CREATED -> HttpStatus.CREATED
-      RenderService.RenderResult.DATA_ALREADY_EXISTS -> HttpStatus.NO_CONTENT
+    val response = when (renderService.renderServiceDataHtml(renderRequest)) {
+      CREATED -> documentCreatedResponse(renderRequest)
+      DATA_ALREADY_EXISTS -> documentAlreadyExistsResponse()
     }
 
-    return ResponseEntity(
-      RenderResponse(
-        renderRequest.id!!,
-        renderRequest.serviceName!!,
-      ),
-      status,
-    )
+    return response
   }
+
+  private fun documentCreatedResponse(renderRequest: RenderRequest) = ResponseEntity(
+    RenderResponse(
+      renderRequest.id!!,
+      renderRequest.serviceName!!,
+    ),
+    HttpStatus.CREATED,
+  )
+
+  private fun documentAlreadyExistsResponse(): ResponseEntity<RenderResponse> = ResponseEntity.noContent().build()
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/S3TestUtil.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/S3TestUtil.kt
@@ -1,0 +1,87 @@
+package uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer
+
+import aws.sdk.kotlin.services.s3.S3Client
+import aws.sdk.kotlin.services.s3.deleteObjects
+import aws.sdk.kotlin.services.s3.headObject
+import aws.sdk.kotlin.services.s3.listObjectsV2
+import aws.sdk.kotlin.services.s3.model.Delete
+import aws.sdk.kotlin.services.s3.model.GetObjectRequest
+import aws.sdk.kotlin.services.s3.model.NotFound
+import aws.sdk.kotlin.services.s3.model.ObjectIdentifier
+import aws.sdk.kotlin.services.s3.putObject
+import aws.smithy.kotlin.runtime.content.ByteStream
+import aws.smithy.kotlin.runtime.content.toByteArray
+import aws.smithy.kotlin.runtime.time.toJvmInstant
+import kotlinx.coroutines.runBlocking
+import org.springframework.boot.test.context.TestComponent
+import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.config.S3Properties
+import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.integration.IntegrationTestBase.S3File
+import java.time.Instant
+
+@TestComponent
+class S3TestUtil(
+  val s3: S3Client,
+  val s3Properties: S3Properties,
+) {
+
+  fun getFile(documentKey: String): String = runBlocking {
+    s3.getObject(
+      GetObjectRequest {
+        bucket = s3Properties.bucketName
+        key = documentKey
+      },
+    ) { it.body?.toByteArray() }?.let { String(it) } ?: ""
+  }
+
+  fun clearBucket() = runBlocking {
+    s3.listObjectsV2 { bucket = s3Properties.bucketName }
+      .contents
+      ?.map { ObjectIdentifier { key = it.key } }
+      ?.takeIf { it.isNotEmpty() }
+      ?.let { identifiers ->
+        s3.deleteObjects {
+          bucket = s3Properties.bucketName
+          delete = Delete {
+            objects = identifiers
+          }
+        }
+      }
+  }
+
+  fun addFilesToBucket(vararg files: S3File) = runBlocking {
+    files.forEach {
+      addFileToBucket(it)
+    }
+  }
+
+  fun addFileToBucket(file: S3File) = runBlocking {
+    s3.putObject {
+      bucket = s3Properties.bucketName
+      key = file.key
+      body = ByteStream.fromString(file.content)
+    }
+  }
+
+  fun documentExists(key: String): Boolean = runBlocking {
+    try {
+      s3.headObject {
+        this.bucket = s3Properties.bucketName
+        this.key = key
+      }
+      true
+    } catch (e: NotFound) {
+      false
+    }
+  }
+
+  fun getFileMetadata(key: String): FileMetadata = runBlocking {
+    s3.getObject(
+      GetObjectRequest {
+        this.bucket = s3Properties.bucketName
+        this.key = key
+      },
+    ) { FileMetadata(it.eTag, it.lastModified?.toJvmInstant()) }
+  }
+
+  data class FileMetadata(val eTag: String?, val lastModified: Instant?)
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/integration/DeveloperControllerDisabledIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/integration/DeveloperControllerDisabledIntTest.kt
@@ -20,7 +20,7 @@ class DeveloperControllerDisabledIntTest : IntegrationTestBase() {
 
   @BeforeEach
   fun setup() {
-    clearS3Bucket()
+    s3TestUtil.clearBucket()
   }
 
   @Nested
@@ -70,7 +70,7 @@ class DeveloperControllerDisabledIntTest : IntegrationTestBase() {
     @Test
     fun `should return status not found when bucket contains files for requested ID`(): Unit = runBlocking {
       val sarId = UUID.randomUUID()
-      addFilesToBucket(
+      s3TestUtil.addFilesToBucket(
         S3File("$sarId/service-A"),
         S3File("$sarId/service-B"),
         S3File("$sarId/service-C"),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/integration/DeveloperControllerEnabledIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/integration/DeveloperControllerEnabledIntTest.kt
@@ -17,12 +17,12 @@ class DeveloperControllerEnabledIntTest : IntegrationTestBase() {
 
   @BeforeEach
   fun setup() {
-    clearS3Bucket()
+    s3TestUtil.clearBucket()
   }
 
   @AfterEach
   fun tearDown() {
-    clearS3Bucket()
+    s3TestUtil.clearBucket()
   }
 
   @Nested
@@ -48,7 +48,7 @@ class DeveloperControllerEnabledIntTest : IntegrationTestBase() {
     fun `should return status 200 and expected content when requested file exists in bucket`(): Unit = runBlocking {
       val subjectAccessRequestId = UUID.randomUUID()
       val serviceName = "service-xyz"
-      addFilesToBucket(S3File("$subjectAccessRequestId/$serviceName.html"))
+      s3TestUtil.addFilesToBucket(S3File("$subjectAccessRequestId/$serviceName.html"))
 
       val resp = webTestClient.get()
         .uri("/subject-access-request/$subjectAccessRequestId/$serviceName")
@@ -88,7 +88,7 @@ class DeveloperControllerEnabledIntTest : IntegrationTestBase() {
       val id1 = UUID.randomUUID()
       val id2 = UUID.randomUUID()
 
-      addFilesToBucket(
+      s3TestUtil.addFilesToBucket(
         S3File("$id1/service-A.html"),
         S3File("$id1/service-B.html"),
         S3File("$id1/service-C.html"),
@@ -120,7 +120,7 @@ class DeveloperControllerEnabledIntTest : IntegrationTestBase() {
     @Test
     fun `should only return files with key ending with dot html `(): Unit = runBlocking {
       val id = UUID.randomUUID()
-      addFilesToBucket(
+      s3TestUtil.addFilesToBucket(
         S3File("$id/service-A.html"),
         S3File("$id/service-A.txt"),
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/integration/wiremock/HmppsAuthMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/integration/wiremock/HmppsAuthMockServer.kt
@@ -81,4 +81,6 @@ class HmppsAuthMockServer : WireMockServer(WIREMOCK_PORT) {
   }
 
   fun verifyGrantTokenIsCalled(times: Int) = verify(times, postRequestedFor(urlEqualTo("/auth/oauth/token")))
+
+  fun verifyGrantTokenIsNeverCalled() = verify(0, postRequestedFor(urlEqualTo("/auth/oauth/token")))
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/integration/wiremock/SarDataSourceApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/integration/wiremock/SarDataSourceApiMockServer.kt
@@ -41,8 +41,28 @@ class SarDataSourceApiMockServer : WireMockServer(8092) {
     )
   }
 
+  fun stubGetSubjectAccessRequestDataEmpty(params: GetSubjectAccessRequestDataParams) {
+    stubFor(
+      get(urlPathEqualTo("/subject-access-request"))
+        .withQueryParam("prn", equalTo(params.prn))
+        .withQueryParam("crn", equalTo(params.crn))
+        .withQueryParam("fromDate", equalTo(params.dateFrom.toString()))
+        .withQueryParam("toDate", equalTo(params.dateTo.toString()))
+        .willReturn(
+          aResponse()
+            .withStatus(204)
+            .withHeader("Content-Type", "application/json"),
+        ),
+    )
+  }
+
   fun verifyGetSubjectAccessRequestDataCalled(times: Int) = verify(
     times,
+    getRequestedFor(urlPathEqualTo("/subject-access-request")),
+  )
+
+  fun verifyGetSubjectAccessRequestDataNeverCalled() = verify(
+    0,
     getRequestedFor(urlPathEqualTo("/subject-access-request")),
   )
 }

--- a/src/test/resources/integration-tests/reference-html-stubs/hmpps-book-secure-move-api-no-data-expected.html
+++ b/src/test/resources/integration-tests/reference-html-stubs/hmpps-book-secure-move-api-no-data-expected.html
@@ -1,0 +1,232 @@
+<style>
+    * {
+        font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
+        font-size: 12pt;
+        color: #0b0c0c;
+    }
+    /* --- HEADINGS --- */
+
+    h1, h2, h3 {
+        color: #0b0c0c;
+        font-weight: 700;
+        display: block;
+        margin-top: 0;
+        margin-inline-start: 0;
+        margin-inline-end: 0;
+    }
+
+    h1 {
+        font-size: 18pt;
+        line-height: 1.09375;
+        margin-top: 20px;
+        margin-bottom: 10px;
+        margin-block-start: 0.67em;
+        margin-block-end: 0.67em;
+    }
+
+    h2 {
+        font-size: 17pt;
+        line-height: 1.0416666667;
+        margin-top: 15px;
+        margin-bottom: 5px;
+        margin-block-start: 0.83em;
+        margin-block-end: 0.83em;
+    }
+
+    h3 {
+        font-size: 16pt;
+        line-height: 1.0416666667;
+        margin-top: 15px;
+        margin-bottom: 5px;
+        margin-block-start: 0.83em;
+        margin-block-end: 0.83em;
+    }
+
+    h4 {
+        font-size: 15pt;
+        line-height: 1.0416666667;
+        margin-top: 15px;
+        margin-bottom: 5px;
+        margin-block-start: 0.83em;
+        margin-block-end: 0.83em;
+    }
+
+    h5 {
+        font-size: 14pt;
+        line-height: 1.0416666667;
+        margin-top: 15px;
+        margin-bottom: 5px;
+        margin-block-start: 0.83em;
+        margin-block-end: 0.83em;
+    }
+
+    /* --- SUMMARY LIST --- */
+
+    table.summary-list {
+        display: table;
+        width: 700px;
+        table-layout: fixed;
+        border-collapse: collapse;
+        margin: 0 0 5px;
+        margin-block-start: 1em;
+        margin-block-end: 1em;
+        margin-inline-start: 0;
+        margin-inline-end: 0;
+    }
+
+    table.summary-list tr {
+        display: table-row;
+        margin: 0 0 20px;
+    }
+
+    table.summary-list tr td {
+        border-bottom: 1px solid #b1b4b6;
+        /*margin-bottom: 5px;*/
+        overflow-wrap: break-word;
+        display: table-cell;
+        /*padding-top: 2px;*/
+        /*padding-bottom: 2px;*/
+        /*padding-right: 0;*/
+        margin-inline-start: 40px;
+        width: 70%;
+        table-layout: fixed;
+        border-collapse: collapse;
+        line-height: 1.25;
+        font-weight: 400;
+        white-space: normal;
+        vertical-align: top;
+    }
+
+    table.summary-list tr td:first-child {
+        font-size: 12pt;
+        width: 30%;
+        font-weight: 700;
+        padding-right: 20px;
+        vertical-align: top;
+    }
+
+    /* --- DATA TABLE --- */
+
+    table.data-table {
+        display: table;
+        width: 700px;
+        table-layout: fixed;
+        border-collapse: collapse;
+        margin: 0 0 5px;
+        margin-block-start: 1em;
+        margin-block-end: 1em;
+        margin-inline-start: 0;
+        margin-inline-end: 0;
+    }
+
+    table.data-table tr {
+        display: table-row;
+        margin: 0 0 20px;
+    }
+
+    table.data-table tr td {
+        border-bottom: 1px solid #b1b4b6;
+        margin-bottom: 5px;
+        overflow-wrap: break-word;
+        display: table-cell;
+        padding-top: 2px;
+        padding-bottom: 2px;
+        padding-right: 0;
+        margin-inline-start: 40px;
+        table-layout: fixed;
+        border-collapse: collapse;
+        line-height: 1.25;
+        font-weight: 400;
+        white-space: pre-wrap;
+        vertical-align: top;
+    }
+
+    table.data-table tr:first-child td {
+        font-size: 12pt;
+        width: 30%;
+        font-weight: 700;
+        padding-right: 20px;
+        border-bottom: none;
+        vertical-align: top;
+    }
+
+    table.data-table tr td.data-column-5 { width: 5% }
+    table.data-table tr td.data-column-10 { width: 10% }
+    table.data-table tr td.data-column-15 { width: 15% }
+    table.data-table tr td.data-column-20 { width: 20% }
+    table.data-table tr td.data-column-25 { width: 25% }
+    table.data-table tr td.data-column-30 { width: 30% }
+    table.data-table tr td.data-column-35 { width: 35% }
+    table.data-table tr td.data-column-40 { width: 40% }
+    table.data-table tr td.data-column-45 { width: 45% }
+    table.data-table tr td.data-column-50 { width: 50% }
+    table.data-table tr td.data-column-55 { width: 55% }
+    table.data-table tr td.data-column-60 { width: 60% }
+    table.data-table tr td.data-column-65 { width: 65% }
+    table.data-table tr td.data-column-70 { width: 70% }
+    table.data-table tr td.data-column-75 { width: 75% }
+    table.data-table tr td.data-column-80 { width: 80% }
+    table.data-table tr td.data-column-85 { width: 85% }
+    table.data-table tr td.data-column-90 { width: 90% }
+    table.data-table tr td.data-column-95 { width: 95% }
+
+    table tr td.data-column-5 { width: 5% }
+    table tr td.data-column-10 { width: 10% }
+    table tr td.data-column-15 { width: 15% }
+    table tr td.data-column-20 { width: 20% }
+    table tr td.data-column-25 { width: 25% }
+    table tr td.data-column-30 { width: 30% }
+    table tr td.data-column-35 { width: 35% }
+    table tr td.data-column-40 { width: 40% }
+    table tr td.data-column-45 { width: 45% }
+    table tr td.data-column-50 { width: 50% }
+    table tr td.data-column-55 { width: 55% }
+    table tr td.data-column-60 { width: 60% }
+    table tr td.data-column-65 { width: 65% }
+    table tr td.data-column-70 { width: 70% }
+    table tr td.data-column-75 { width: 75% }
+    table tr td.data-column-80 { width: 80% }
+    table tr td.data-column-85 { width: 85% }
+    table tr td.data-column-90 { width: 90% }
+    table tr td.data-column-95 { width: 95% }
+
+    table.summary-list tr td.data-column-5 { width: 5% }
+    table.summary-list tr td.data-column-10 { width: 10% }
+    table.summary-list tr td.data-column-15 { width: 15% }
+    table.summary-list tr td.data-column-20 { width: 20% }
+    table.summary-list tr td.data-column-25 { width: 25% }
+    table.summary-list tr td.data-column-30 { width: 30% }
+    table.summary-list tr td.data-column-35 { width: 35% }
+    table.summary-list tr td.data-column-40 { width: 40% }
+    table.summary-list tr td.data-column-45 { width: 45% }
+    table.summary-list tr td.data-column-50 { width: 50% }
+    table.summary-list tr td.data-column-55 { width: 55% }
+    table.summary-list tr td.data-column-60 { width: 60% }
+    table.summary-list tr td.data-column-65 { width: 65% }
+    table.summary-list tr td.data-column-70 { width: 70% }
+    table.summary-list tr td.data-column-75 { width: 75% }
+    table.summary-list tr td.data-column-80 { width: 80% }
+    table.summary-list tr td.data-column-85 { width: 85% }
+    table.summary-list tr td.data-column-90 { width: 90% }
+    table.summary-list tr td.data-column-95 { width: 95% }
+
+    ul {
+        padding: 0 0 0 10px;
+    }
+
+</style>
+
+<!-- It was unclear exactly what data returned was owned by and relevant to Book a Secure Move -->
+<!-- Because of this, this template includes only: -->
+<!-- - data > relationships > moves (not all data included) -->
+
+<h1>Book a secure move</h1>
+
+
+
+    <p>No Data Held</p>
+
+
+
+
+

--- a/src/test/resources/integration-tests/reference-html-stubs/hmpps-incentives-api-no-data-expected.html
+++ b/src/test/resources/integration-tests/reference-html-stubs/hmpps-incentives-api-no-data-expected.html
@@ -1,0 +1,223 @@
+<style>
+    * {
+        font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
+        font-size: 12pt;
+        color: #0b0c0c;
+    }
+    /* --- HEADINGS --- */
+
+    h1, h2, h3 {
+        color: #0b0c0c;
+        font-weight: 700;
+        display: block;
+        margin-top: 0;
+        margin-inline-start: 0;
+        margin-inline-end: 0;
+    }
+
+    h1 {
+        font-size: 18pt;
+        line-height: 1.09375;
+        margin-top: 20px;
+        margin-bottom: 10px;
+        margin-block-start: 0.67em;
+        margin-block-end: 0.67em;
+    }
+
+    h2 {
+        font-size: 17pt;
+        line-height: 1.0416666667;
+        margin-top: 15px;
+        margin-bottom: 5px;
+        margin-block-start: 0.83em;
+        margin-block-end: 0.83em;
+    }
+
+    h3 {
+        font-size: 16pt;
+        line-height: 1.0416666667;
+        margin-top: 15px;
+        margin-bottom: 5px;
+        margin-block-start: 0.83em;
+        margin-block-end: 0.83em;
+    }
+
+    h4 {
+        font-size: 15pt;
+        line-height: 1.0416666667;
+        margin-top: 15px;
+        margin-bottom: 5px;
+        margin-block-start: 0.83em;
+        margin-block-end: 0.83em;
+    }
+
+    h5 {
+        font-size: 14pt;
+        line-height: 1.0416666667;
+        margin-top: 15px;
+        margin-bottom: 5px;
+        margin-block-start: 0.83em;
+        margin-block-end: 0.83em;
+    }
+
+    /* --- SUMMARY LIST --- */
+
+    table.summary-list {
+        display: table;
+        width: 700px;
+        table-layout: fixed;
+        border-collapse: collapse;
+        margin: 0 0 5px;
+        margin-block-start: 1em;
+        margin-block-end: 1em;
+        margin-inline-start: 0;
+        margin-inline-end: 0;
+    }
+
+    table.summary-list tr {
+        display: table-row;
+        margin: 0 0 20px;
+    }
+
+    table.summary-list tr td {
+        border-bottom: 1px solid #b1b4b6;
+        /*margin-bottom: 5px;*/
+        overflow-wrap: break-word;
+        display: table-cell;
+        /*padding-top: 2px;*/
+        /*padding-bottom: 2px;*/
+        /*padding-right: 0;*/
+        margin-inline-start: 40px;
+        width: 70%;
+        table-layout: fixed;
+        border-collapse: collapse;
+        line-height: 1.25;
+        font-weight: 400;
+        white-space: normal;
+        vertical-align: top;
+    }
+
+    table.summary-list tr td:first-child {
+        font-size: 12pt;
+        width: 30%;
+        font-weight: 700;
+        padding-right: 20px;
+        vertical-align: top;
+    }
+
+    /* --- DATA TABLE --- */
+
+    table.data-table {
+        display: table;
+        width: 700px;
+        table-layout: fixed;
+        border-collapse: collapse;
+        margin: 0 0 5px;
+        margin-block-start: 1em;
+        margin-block-end: 1em;
+        margin-inline-start: 0;
+        margin-inline-end: 0;
+    }
+
+    table.data-table tr {
+        display: table-row;
+        margin: 0 0 20px;
+    }
+
+    table.data-table tr td {
+        border-bottom: 1px solid #b1b4b6;
+        margin-bottom: 5px;
+        overflow-wrap: break-word;
+        display: table-cell;
+        padding-top: 2px;
+        padding-bottom: 2px;
+        padding-right: 0;
+        margin-inline-start: 40px;
+        table-layout: fixed;
+        border-collapse: collapse;
+        line-height: 1.25;
+        font-weight: 400;
+        white-space: pre-wrap;
+        vertical-align: top;
+    }
+
+    table.data-table tr:first-child td {
+        font-size: 12pt;
+        width: 30%;
+        font-weight: 700;
+        padding-right: 20px;
+        border-bottom: none;
+        vertical-align: top;
+    }
+
+    table.data-table tr td.data-column-5 { width: 5% }
+    table.data-table tr td.data-column-10 { width: 10% }
+    table.data-table tr td.data-column-15 { width: 15% }
+    table.data-table tr td.data-column-20 { width: 20% }
+    table.data-table tr td.data-column-25 { width: 25% }
+    table.data-table tr td.data-column-30 { width: 30% }
+    table.data-table tr td.data-column-35 { width: 35% }
+    table.data-table tr td.data-column-40 { width: 40% }
+    table.data-table tr td.data-column-45 { width: 45% }
+    table.data-table tr td.data-column-50 { width: 50% }
+    table.data-table tr td.data-column-55 { width: 55% }
+    table.data-table tr td.data-column-60 { width: 60% }
+    table.data-table tr td.data-column-65 { width: 65% }
+    table.data-table tr td.data-column-70 { width: 70% }
+    table.data-table tr td.data-column-75 { width: 75% }
+    table.data-table tr td.data-column-80 { width: 80% }
+    table.data-table tr td.data-column-85 { width: 85% }
+    table.data-table tr td.data-column-90 { width: 90% }
+    table.data-table tr td.data-column-95 { width: 95% }
+
+    table tr td.data-column-5 { width: 5% }
+    table tr td.data-column-10 { width: 10% }
+    table tr td.data-column-15 { width: 15% }
+    table tr td.data-column-20 { width: 20% }
+    table tr td.data-column-25 { width: 25% }
+    table tr td.data-column-30 { width: 30% }
+    table tr td.data-column-35 { width: 35% }
+    table tr td.data-column-40 { width: 40% }
+    table tr td.data-column-45 { width: 45% }
+    table tr td.data-column-50 { width: 50% }
+    table tr td.data-column-55 { width: 55% }
+    table tr td.data-column-60 { width: 60% }
+    table tr td.data-column-65 { width: 65% }
+    table tr td.data-column-70 { width: 70% }
+    table tr td.data-column-75 { width: 75% }
+    table tr td.data-column-80 { width: 80% }
+    table tr td.data-column-85 { width: 85% }
+    table tr td.data-column-90 { width: 90% }
+    table tr td.data-column-95 { width: 95% }
+
+    table.summary-list tr td.data-column-5 { width: 5% }
+    table.summary-list tr td.data-column-10 { width: 10% }
+    table.summary-list tr td.data-column-15 { width: 15% }
+    table.summary-list tr td.data-column-20 { width: 20% }
+    table.summary-list tr td.data-column-25 { width: 25% }
+    table.summary-list tr td.data-column-30 { width: 30% }
+    table.summary-list tr td.data-column-35 { width: 35% }
+    table.summary-list tr td.data-column-40 { width: 40% }
+    table.summary-list tr td.data-column-45 { width: 45% }
+    table.summary-list tr td.data-column-50 { width: 50% }
+    table.summary-list tr td.data-column-55 { width: 55% }
+    table.summary-list tr td.data-column-60 { width: 60% }
+    table.summary-list tr td.data-column-65 { width: 65% }
+    table.summary-list tr td.data-column-70 { width: 70% }
+    table.summary-list tr td.data-column-75 { width: 75% }
+    table.summary-list tr td.data-column-80 { width: 80% }
+    table.summary-list tr td.data-column-85 { width: 85% }
+    table.summary-list tr td.data-column-90 { width: 90% }
+    table.summary-list tr td.data-column-95 { width: 95% }
+
+    ul {
+        padding: 0 0 0 10px;
+    }
+
+</style>
+
+<h1>Incentives</h1>
+
+
+    <p>No data held</p>
+


### PR DESCRIPTION
- Updated `/render` endpoint to return status 204 when document exists in bucket.
- Updated service to handle scenario where SAR service returns 204 no content.
- Added int test to verify scenario where no data is held.