### PR TITLE
HAAR-3806: added templated generation util for development

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,3 +39,27 @@ tasks {
     compilerOptions.jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21
   }
 }
+
+tasks.register<TemplateGenerator>("generateReport") {
+  group = "templates"
+  description = "Generate subject access report HTML for the specified service name"
+  classpath = sourceSets["test"].runtimeClasspath
+  mainClass = "uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.templateGenerator.TemplateDevelopmentUtilKt"
+  environment = mapOf("TEST_RESOURCES_DIR" to project.rootDir.resolve("src/test/resources"))
+}
+
+abstract class TemplateGenerator : JavaExec() {
+  private lateinit var serviceName: String
+
+  @Option(
+    option = "service",
+    description = "The service name to generate report html for e.g 'hmpps-book-secure-move-api'",
+  )
+  fun setServiceName(serviceName: String) {
+    this.serviceName = serviceName
+    args(serviceName)
+  }
+
+  @Input
+  fun getServiceName(): String = serviceName
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/templateGenerator/README.md
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/templateGenerator/README.md
@@ -23,7 +23,23 @@ subject access request endpoint. The response stubs live under:
 src/test/resources/integration-tests.service-response-stubs
 ```
 If a stub does not already exist for your service add a new file under this directory. Stub files **must** follow the 
-naming convention `${SERVICE_NAME}-response.json` e.g. `hmpps-book-secure-move-api-response.json` 
+naming convention `${SERVICE_NAME}-response.json` e.g. `hmpps-book-secure-move-api-response.json`
+
+### Data transformations
+Deployed instances of the HTML renderer transform certain values in the API response JSON to a user-friendly or 
+sanitised version. Examples of fields include: 
+- Location IDs
+- User IDs
+- Prison IDs
+
+The template development tool does not have the configuration to perform these transformations so instead uses a set 
+fixed values for each transformation type. For example:
+- All userIds are transformed to `"Homer Simpson"`
+- All prison IDs are transformed to `"HMPPS Mordor`
+- And all DPS location IDs are transformed to `"Hogwarts"`
+
+The presences of these values in the generated HTML is expected, it simply means certain fields have been transformed 
+via the template helpers.
 
 ## Generating a HTML report for your service
 **Prerequisites:**

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/templateGenerator/README.md
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/templateGenerator/README.md
@@ -1,0 +1,44 @@
+# Template Development Util
+A development tool that generates SAR report HTML from stubbed service data. If you're developing a new or updating 
+an existing service template you can use this tool to view the HTML the service will create for your service data.
+
+## Getting started
+
+### Templates
+The **hmpps-subject-access-request-html-renderer** uses mustache templates to generate report HTML. To change the 
+content/format of the HTML generated for a service you must update the corresponding service template. The templates 
+live under 
+```
+src/main/resources/templates
+```
+To onboard a new service add your service template to this directory. Templates **must** follow the naming convention 
+`template_${SERVICE_NAME}.mustache` e.g. `template_hmpps-book-secure-move-api.mustache`
+
+### Service Response Stubs 
+The template development util requires a json response stub file in order to generate a mock report HTML the specified 
+service. The json stub is used to mock the data returned by a given service. The stub should match the structure of the 
+data returned by the real service's subject access request endpoint. The response stubs live under: 
+```
+src/test/resources/integration-tests.service-response-stubs
+```
+If a stub does not already exist for your service add a new file under this directory. Stub files **must** follow the 
+naming convention `${SERVICE_NAME}-response.json` e.g. `hmpps-book-secure-move-api-response.json` 
+
+## Generating a HTML report for your service
+**Prerequisites:**
+- A template exists for the target service.
+- A response stub json file exists for the target service.
+
+From the project root run:
+```bash
+./gradlew generateReport --service=${SERVICE_NAME}
+```
+```
+## Example
+./gradlew generateReport --service=hmpps-book-secure-move-api
+```
+If successful the util will output a link to the generated HTML file which will open the file in your browser. 
+Alternatively you can view the file under:
+```
+src/test/resources/integration-tests/reference-html-stubs
+```

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/templateGenerator/README.md
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/templateGenerator/README.md
@@ -1,11 +1,12 @@
 # Template Development Util
-A development tool that generates SAR report HTML from stubbed service data. If you're developing a new or updating 
-an existing service template you can use this tool to view the HTML the service will create for your service data.
+A development tool that allows users to generate SAR report HTML from stubbed service data. If you're developing a new 
+template or updating an existing template you can use this tool to rapidly preview the HTML the service will create for 
+your service data as you create/modify the template code.
 
 ## Getting started
 
 ### Templates
-The **hmpps-subject-access-request-html-renderer** uses mustache templates to generate report HTML. To change the 
+The **hmpps-subject-access-request-html-renderer** uses mustache templates to generate the report HTML. To change the 
 content/format of the HTML generated for a service you must update the corresponding service template. The templates 
 live under 
 ```
@@ -15,9 +16,9 @@ To onboard a new service add your service template to this directory. Templates 
 `template_${SERVICE_NAME}.mustache` e.g. `template_hmpps-book-secure-move-api.mustache`
 
 ### Service Response Stubs 
-The template development util requires a json response stub file in order to generate a mock report HTML the specified 
-service. The json stub is used to mock the data returned by a given service. The stub should match the structure of the 
-data returned by the real service's subject access request endpoint. The response stubs live under: 
+The template development util requires a json response stub file in order to generate a mock report HTML document for 
+the specified service. The service response stub should match the structure of the data returned by the real service's 
+subject access request endpoint. The response stubs live under: 
 ```
 src/test/resources/integration-tests.service-response-stubs
 ```

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/templateGenerator/TemplateDevelopmentUtil.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/templateGenerator/TemplateDevelopmentUtil.kt
@@ -1,0 +1,117 @@
+package uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.templateGenerator
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.mockito.kotlin.mock
+import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.client.LocationsApiClient
+import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.client.NomisMappingApiClient
+import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.controller.entity.RenderRequest
+import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.repository.LocationDetailsRepository
+import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.repository.PrisonDetailsRepository
+import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.repository.UserDetailsRepository
+import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.templates.TemplateHelpers
+import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.templates.TemplateResources
+import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.templates.TemplateService
+import java.io.ByteArrayOutputStream
+import java.io.FileInputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.UUID
+import kotlin.io.path.notExists
+
+/**
+ * Developer util class to aid template development/testing.
+ */
+fun main(args: Array<String>?) {
+  if (args.isNullOrEmpty()) {
+    throw IllegalArgumentException("serviceName argument required")
+  }
+
+  TemplateGeneratorUtil().generateServiceHtml(args[0])
+}
+
+class TemplateGeneratorUtil {
+  private val prisonDetailsRepository: PrisonDetailsRepository = mock()
+  private val userDetailsRepository: UserDetailsRepository = mock()
+  private val locationDetailsRepository: LocationDetailsRepository = mock()
+  private val locationsApiClient: LocationsApiClient = mock()
+  private val nomisMappingApiClient: NomisMappingApiClient = mock()
+
+  private val templateResources: TemplateResources = TemplateResources()
+
+  private val templateHelpers = TemplateHelpers(
+    prisonDetailsRepository,
+    userDetailsRepository,
+    locationDetailsRepository,
+    locationsApiClient,
+    nomisMappingApiClient,
+  )
+
+  private val templateService: TemplateService = TemplateService(templateHelpers, templateResources)
+
+  fun generateServiceHtml(serviceName: String) {
+    println()
+    log("Rendering templates for $serviceName")
+
+    try {
+      val renderRequest = RenderRequest(id = UUID.randomUUID(), serviceName = serviceName)
+      val output = renderHtml(renderRequest).use { os -> writeToFile(serviceName, os) }
+
+      println()
+      log("Successfully generated HTML for service $serviceName:")
+      log("file:///$output\n")
+    } catch (e: Exception) {
+      log("failed to render template for service $serviceName, ${e.message}")
+      throw e
+    }
+  }
+
+  private fun writeToFile(serviceName: String, os: ByteArrayOutputStream): Path {
+    val output = getOutputFile(serviceName)
+    Files.write(output, os.toByteArray())
+    return output
+  }
+
+  private fun renderHtml(renderRequest: RenderRequest): ByteArrayOutputStream = templateService
+    .renderServiceDataHtml(
+      renderRequest = renderRequest,
+      data = getServiceResponseStubData(renderRequest.serviceName!!),
+    ) ?: throw renderedTemplateNullException(renderRequest.serviceName!!)
+
+  private fun getServiceResponseStubData(serviceName: String): ArrayList<*>? {
+    val path = assertResponseStubJsonExists(serviceName)
+    log("Using response stub data: file:///$path ")
+
+    return FileInputStream(path.toFile()).use { inputStream ->
+      inputStream.use {
+        ObjectMapper().readValue(inputStream, Map::class.java)
+      }
+    }.let { it["content"] as ArrayList<*>? }
+  }
+
+  private fun assertResponseStubJsonExists(serviceName: String): Path {
+    val target = getResponseJsonStub(serviceName)
+
+    if (target.notExists()) {
+      throw responseStubJsonNotFoundException(target)
+    }
+
+    return target
+  }
+
+  private fun getOutputFile(serviceName: String) = Paths.get(getTestResourcesDir())
+    .resolve("integration-tests/reference-html-stubs/$serviceName-expected.html")
+
+  private fun getResponseJsonStub(serviceName: String) = Paths.get(getTestResourcesDir())
+    .resolve("integration-tests.service-response-stubs/$serviceName-response.json")
+
+  private fun getTestResourcesDir() = System.getenv("TEST_RESOURCES_DIR")
+
+  private fun renderedTemplateNullException(serviceName: String) = RuntimeException("Rendered HTML for service $serviceName was null")
+
+  private fun responseStubJsonNotFoundException(target: Path) = RuntimeException("response stub json file $target not found")
+
+  private fun log(message: String) {
+    println("[generateTemplate] $message")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/templateGenerator/TemplateDevelopmentUtil.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/templateGenerator/TemplateDevelopmentUtil.kt
@@ -1,10 +1,16 @@
 package uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.templateGenerator
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.client.LocationsApiClient
 import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.client.NomisMappingApiClient
 import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.controller.entity.RenderRequest
+import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.models.LocationDetail
+import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.models.PrisonDetail
+import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.models.UserDetail
 import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.repository.LocationDetailsRepository
 import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.repository.PrisonDetailsRepository
 import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.repository.UserDetailsRepository
@@ -48,6 +54,22 @@ class TemplateGeneratorUtil {
   )
 
   private val templateService: TemplateService = TemplateService(templateHelpers, templateResources)
+
+  init {
+    whenever(userDetailsRepository.findByUsername(any())).doAnswer {
+      val input = it.arguments[0] as String
+      UserDetail(input, "Homer Simpson")
+    }
+
+    whenever(prisonDetailsRepository.findByPrisonId(any())).doAnswer {
+      PrisonDetail(it.arguments[0] as String, "HMPPS Mordor")
+    }
+
+    whenever(locationDetailsRepository.findByDpsId(any())).doAnswer {
+      val dpsId = it.arguments[0] as String
+      LocationDetail(dpsId, 666, "Hogwarts")
+    }
+  }
 
   fun generateServiceHtml(serviceName: String) {
     println()


### PR DESCRIPTION
Added a custom gradle task `generateReport` which allows you to generate the SAR HTML for a given service from stubbed data. 

README contains instructions on how to use it.