### PR TITLE
MAPB-358: ✨ Show SAR baseline fields in restricted patients

### DIFF
--- a/src/main/resources/templates/template_hmpps-restricted-patients-api.mustache
+++ b/src/main/resources/templates/template_hmpps-restricted-patients-api.mustache
@@ -5,6 +5,12 @@
         <tr><td>Discharge time</td><td>{{ formatDate dischargeTime }}</td></tr>
         <tr><td>Hospital location</td><td>{{ hospitalLocationDescription }}</td></tr>
         <tr><td>Supporting prison</td><td>{{ getPrisonName supportingPrisonId }}</td></tr>
+        <tr><td>From location</td><td>{{ optionalValue fromLocationName }}</td></tr>
+        <tr><td>Comment</td><td>{{ optionalValue commentText }}</td></tr>
+        <tr><td>Created date</td><td>{{ formatDate createdDate }}</td></tr>
+        <tr><td>Created by</td><td>{{ optionalValue createdUserSurname }}</td></tr>
+        <tr><td>Modified date</td><td>{{ formatDate modifiedDate }}</td></tr>
+        <tr><td>Modified by</td><td>{{ optionalValue modifiedUserSurname }}</td></tr>
     </table>
 {{/.}}
 {{^.}}

--- a/src/test/resources/integration-tests.service-response-stubs/hmpps-restricted-patients-api-response.json
+++ b/src/test/resources/integration-tests.service-response-stubs/hmpps-restricted-patients-api-response.json
@@ -3,6 +3,12 @@
     "prisonerNumber": "A1234AA",
     "supportingPrisonId": "EXI",
     "hospitalLocationDescription": "Weston Park Hospital",
-    "dischargeTime": "2024-09-05T08:50:44.19812"
+    "dischargeTime": "2024-09-05T08:50:44.19812",
+    "fromLocationName": "Moorland (HMP & YOI)",
+    "commentText": "Prisoner was released to hospital",
+    "createdDate": "2024-09-04T10:00:00",
+    "createdUserSurname": "Smith",
+    "modifiedDate": "2024-09-10T11:22:33",
+    "modifiedUserSurname": "Jones"
   }
 }

--- a/src/test/resources/integration-tests/reference-html-stubs/hmpps-restricted-patients-api-expected.html
+++ b/src/test/resources/integration-tests/reference-html-stubs/hmpps-restricted-patients-api-expected.html
@@ -228,6 +228,12 @@
         <tr><td>Discharge time</td><td>05 September 2024, 8:50:44 am</td></tr>
         <tr><td>Hospital location</td><td>Weston Park Hospital</td></tr>
         <tr><td>Supporting prison</td><td>HMPPS Mordor</td></tr>
+        <tr><td>From location</td><td>Moorland (HMP &amp; YOI)</td></tr>
+        <tr><td>Comment</td><td>Prisoner was released to hospital</td></tr>
+        <tr><td>Created date</td><td>04 September 2024, 10:00:00 am</td></tr>
+        <tr><td>Created by</td><td>Smith</td></tr>
+        <tr><td>Modified date</td><td>10 September 2024, 11:22:33 am</td></tr>
+        <tr><td>Modified by</td><td>Jones</td></tr>
     </table>
 
 


### PR DESCRIPTION
## Summary

Updates the restricted patients mustache template to display the new SAR baseline fields now returned by `hmpps-restricted-patients-api`. New rows added:

- From location (name)
- Comment
- Created date / Created by (surname)
- Modified date / Modified by (surname)

Dates use the `formatDate` helper; nullable text uses `optionalValue` so missing fields render as "No Data Held".

These fields were flagged as gaps in the [MaP Data Dictionary](https://dsdmoj.atlassian.net/wiki/spaces/MAP/pages/5880447165/Data+Dictionary+-+Move+a+Prisoner+MaP) SAR baselining exercise ([MAPB-358](https://dsdmoj.atlassian.net/browse/MAPB-358)).

### Why no `getPrisonName` / `getUserLastName` helpers for the new fields?

The companion API PR pre-resolves names and surnames producer-side (matching the existing `hospitalLocationDescription` precedent). The template just prints the values. `supportingPrisonId` continues to use `getPrisonName` as before — not touched in this PR.

### Companion PR

Producer-side change that emits these new JSON fields lives in [hmpps-restricted-patients-api](https://github.com/ministryofjustice/hmpps-restricted-patients-api). Both PRs should be merged together — without the API change, the new template rows will render as "No Data Held".

[MAPB-358]: https://dsdmoj.atlassian.net/browse/MAPB-358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ