### PR TITLE
HAAR-5632: fix for template version logic

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/repository/TemplateVersionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/repository/TemplateVersionRepository.kt
@@ -8,6 +8,7 @@ import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.models.TemplateVersion
 import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.models.TemplateVersionStatus
+import java.time.LocalDateTime
 import java.util.UUID
 
 @Repository
@@ -22,6 +23,43 @@ interface TemplateVersionRepository : JpaRepository<TemplateVersion, UUID> {
   fun findLatestByServiceConfigurationId(
     @Param("serviceConfigId") serviceConfigurationId: UUID,
   ): TemplateVersion?
+
+
+
+  @Query(
+    "SELECT tv FROM TemplateVersion tv " +
+      "WHERE tv.serviceConfiguration.id = :serviceConfigId " +
+      "AND tv.status = 'PUBLISHED' " +
+      "ORDER BY tv.createdAt DESC, tv.version DESC " +
+      "LIMIT 1",
+  )
+  fun findLatestPublishedByServiceConfigurationId(serviceConfigId: UUID): TemplateVersion?
+
+  /**
+   * Get the latest PENDING version created after the latest PUBLISHED version, OR the latest PENDING version if no
+   * PUBLISHED version exists.
+   */
+  @Query("""
+    SELECT v FROM TemplateVersion v
+    WHERE v.serviceConfiguration.id = :serviceConfigId
+    AND v.status = 'PENDING'
+    AND v.createdAt > COALESCE(
+        (
+            SELECT MAX(v2.createdAt) 
+            FROM TemplateVersion v2
+            WHERE v2.serviceConfiguration.id = :serviceConfigId
+            AND v2.status = 'PUBLISHED'
+            
+        ),
+        :defaultCreatedAt
+    )
+    ORDER BY v.createdAt DESC
+  """)
+  fun findLatestPendingByServiceConfigurationId(
+    @Param("serviceConfigId") serviceConfigId: UUID,
+    @Param("defaultCreatedAt") defaultCreatedAt: LocalDateTime = LocalDateTime.of(1970, 1, 1, 0, 0, 0)
+  ): TemplateVersion?
+
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   fun findFirstByIdAndVersionAndFileHashAndStatusOrderByVersionDesc(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/repository/TemplateVersionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/repository/TemplateVersionRepository.kt
@@ -15,23 +15,12 @@ import java.util.UUID
 interface TemplateVersionRepository : JpaRepository<TemplateVersion, UUID> {
 
   @Query(
-    "SELECT tv FROM TemplateVersion tv " +
-      "WHERE tv.serviceConfiguration.id = :serviceConfigId " +
-      "ORDER BY tv.createdAt DESC, tv.version DESC " +
-      "LIMIT 1",
-  )
-  fun findLatestByServiceConfigurationId(
-    @Param("serviceConfigId") serviceConfigurationId: UUID,
-  ): TemplateVersion?
-
-
-
-  @Query(
-    "SELECT tv FROM TemplateVersion tv " +
-      "WHERE tv.serviceConfiguration.id = :serviceConfigId " +
-      "AND tv.status = 'PUBLISHED' " +
-      "ORDER BY tv.createdAt DESC, tv.version DESC " +
-      "LIMIT 1",
+    """
+      SELECT tv FROM TemplateVersion tv
+      WHERE tv.serviceConfiguration.id = :serviceConfigId
+      AND tv.status = 'PUBLISHED' 
+      ORDER BY tv.createdAt DESC, tv.version DESC LIMIT 1
+    """,
   )
   fun findLatestPublishedByServiceConfigurationId(serviceConfigId: UUID): TemplateVersion?
 
@@ -39,7 +28,8 @@ interface TemplateVersionRepository : JpaRepository<TemplateVersion, UUID> {
    * Get the latest PENDING version created after the latest PUBLISHED version, OR the latest PENDING version if no
    * PUBLISHED version exists.
    */
-  @Query("""
+  @Query(
+    """
     SELECT v FROM TemplateVersion v
     WHERE v.serviceConfiguration.id = :serviceConfigId
     AND v.status = 'PENDING'
@@ -54,12 +44,12 @@ interface TemplateVersionRepository : JpaRepository<TemplateVersion, UUID> {
         :defaultCreatedAt
     )
     ORDER BY v.createdAt DESC
-  """)
+  """,
+  )
   fun findLatestPendingByServiceConfigurationId(
     @Param("serviceConfigId") serviceConfigId: UUID,
-    @Param("defaultCreatedAt") defaultCreatedAt: LocalDateTime = LocalDateTime.of(1970, 1, 1, 0, 0, 0)
+    @Param("defaultCreatedAt") defaultCreatedAt: LocalDateTime = LocalDateTime.of(1970, 1, 1, 0, 0, 0),
   ): TemplateVersion?
-
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   fun findFirstByIdAndVersionAndFileHashAndStatusOrderByVersionDesc(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/template/TemplateVersionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/template/TemplateVersionService.kt
@@ -81,14 +81,14 @@ class TemplateVersionService(
       templateVersionRepository.findLatestPendingByServiceConfigurationId(serviceConfigId)
         ?.takeIf { it.fileHash == serviceTemplateHash }
         ?.let {
-        publishPendingTemplateVersion(it, renderRequest, serviceTemplateHash)
+          publishPendingTemplateVersion(it, renderRequest, serviceTemplateHash)
 
-        templateVersionHealthService.updateHealthStatusIfChanged(
-          serviceConfiguration = serviceConfiguration,
-          newStatus = HEALTHY,
-        )
-        it
-      } ?: run {
+          templateVersionHealthService.updateHealthStatusIfChanged(
+            serviceConfiguration = serviceConfiguration,
+            newStatus = HEALTHY,
+          )
+          it
+        } ?: run {
         log.error(
           "service template hash mismatch: serviceName={}, serviceTemplateHash={}",
           serviceConfiguration.serviceName,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/template/TemplateVersionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/template/TemplateVersionService.kt
@@ -60,8 +60,9 @@ class TemplateVersionService(
 
     val serviceConfiguration = getServiceConfiguration(renderRequest)
     val serviceTemplateHash = getSha256HashValue(serviceTemplate)
+    val serviceConfigId = serviceConfiguration.id
 
-    return templateVersionRepository.findLatestByServiceConfigurationId(serviceConfiguration.id)
+    return templateVersionRepository.findLatestPublishedByServiceConfigurationId(serviceConfigId)
       ?.takeIf { it.fileHash == serviceTemplateHash }
       ?.let {
         log.info(
@@ -71,9 +72,16 @@ class TemplateVersionService(
           it.status,
           serviceConfiguration.serviceName,
         )
-        if (TemplateVersionStatus.PENDING == it.status) {
-          publishPendingTemplateVersion(it, renderRequest, serviceTemplateHash)
-        }
+        templateVersionHealthService.updateHealthStatusIfChanged(
+          serviceConfiguration = serviceConfiguration,
+          newStatus = HEALTHY,
+        )
+        it
+      } ?: run {
+      templateVersionRepository.findLatestPendingByServiceConfigurationId(serviceConfigId)
+        ?.takeIf { it.fileHash == serviceTemplateHash }
+        ?.let {
+        publishPendingTemplateVersion(it, renderRequest, serviceTemplateHash)
 
         templateVersionHealthService.updateHealthStatusIfChanged(
           serviceConfiguration = serviceConfiguration,
@@ -81,15 +89,22 @@ class TemplateVersionService(
         )
         it
       } ?: run {
-      templateVersionHealthService.updateHealthStatusIfChanged(
-        serviceConfiguration = serviceConfiguration,
-        newStatus = UNHEALTHY,
-      )
+        log.error(
+          "service template hash mismatch: serviceName={}, serviceTemplateHash={}",
+          serviceConfiguration.serviceName,
+          serviceTemplateHash,
+        )
 
-      throw templateHashMatchFailureException(
-        renderRequest = renderRequest,
-        serviceTemplateHash = serviceTemplateHash,
-      )
+        templateVersionHealthService.updateHealthStatusIfChanged(
+          serviceConfiguration = serviceConfiguration,
+          newStatus = UNHEALTHY,
+        )
+
+        throw templateHashMatchFailureException(
+          renderRequest = renderRequest,
+          serviceTemplateHash = serviceTemplateHash,
+        )
+      }
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/integration/RenderControllerTemplateMigratedIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/integration/RenderControllerTemplateMigratedIntTest.kt
@@ -44,6 +44,9 @@ class RenderControllerTemplateMigratedIntTest : IntegrationTestBase() {
   private val templateV2Path = "/templates/hmpps-test-service-migrated-template-v2.mustache"
   private val templateV2Hash = "b8d6be8b37d1f2c07c243b09a6863f31bfa4ce53cb5c9e5cf1ba14dec18befc5"
 
+  private val templateV3Path = "/templates/hmpps-test-service-migrated-template-v3.mustache"
+  private val templateV3Hash = "ec192b13b63c6d297ad6f249e7d2742546cdbb45dbf90a6bf3b714471b63021f"
+
   private val serviceName = "hmpps-test-service-migrated-template"
   private val serviceLabel = "HMPPS Test Service Template Migrated"
 
@@ -81,7 +84,7 @@ class RenderControllerTemplateMigratedIntTest : IntegrationTestBase() {
     version = 3,
     createdAt = LocalDateTime.now().minusHours(12),
     publishedAt = null,
-    fileHash = templateV2Hash,
+    fileHash = templateV3Hash,
   )
 
   @Autowired
@@ -140,7 +143,7 @@ class RenderControllerTemplateMigratedIntTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `should return success get service template hash matches the PENDING template version`() {
+    fun `should return success when get service template hash matches the PENDING template version`() {
       templateVersionRepository.saveAll(
         listOf(
           templateVersion1Published,
@@ -157,7 +160,7 @@ class RenderControllerTemplateMigratedIntTest : IntegrationTestBase() {
       assertServiceHtmlDocumentDoesNotAlreadyExist(renderRequest)
       hmppsAuthReturnsValidAuthToken()
       hmppsServiceReturnsDataForRequest(renderRequest)
-      hmppsServiceReturnServiceTemplate(getResourceAsString(templateV2Path))
+      hmppsServiceReturnServiceTemplate(getResourceAsString(templateV3Path))
 
       val response = sendRenderTemplateRequest(renderRequestEntity = renderRequestEntity)
 
@@ -169,10 +172,52 @@ class RenderControllerTemplateMigratedIntTest : IntegrationTestBase() {
       assertLegacyFunctionalityServiceDataJsonFileDoesNotExistsInBucket(renderRequest)
       assertUploadedHtmlMatchesExpected(
         renderRequest,
-        getExpectedHtmlString("hmpps-test-service-migrated-template-v2"),
+        getExpectedHtmlString("hmpps-test-service-migrated-template-v3"),
       )
       assertThatTemplateVersionIsPublished(templateVersion3Pending.id)
       assertStoredTemplateVersionMatchesExpected(renderRequest, "v3")
+
+      assertTemplateVersionHealthStatusEquals(
+        serviceConfiguration = renderRequest.serviceConfiguration,
+        expectedStatus = HealthStatusType.HEALTHY,
+      )
+    }
+
+    @Test
+    fun `should return success when service template hash matches v1 PUBLISHED template version and there is a v2 PENDING template version created afterward`() {
+      templateVersionRepository.saveAll(
+        listOf(
+          templateVersion1Published,
+          templateVersion3Pending,
+        ),
+      )
+
+      assertThatTemplateVersionIsPending(templateVersion3Pending.id)
+
+      val renderRequestEntity = newRenderRequestFor(testServiceConfiguration)
+      val renderRequest = RenderRequest(renderRequestEntity, testServiceConfiguration)
+
+      assertServiceHtmlDocumentDoesNotAlreadyExist(renderRequest)
+      hmppsAuthReturnsValidAuthToken()
+      hmppsServiceReturnsDataForRequest(renderRequest)
+      hmppsServiceReturnServiceTemplate(getResourceAsString(templateV1Path))
+      hmppsServiceReturnsAttachmentForRequest("small.jpg", "image/jpeg")
+
+      val response = sendRenderTemplateRequest(renderRequestEntity = renderRequestEntity)
+
+      assertRenderTemplateSuccessResponse(response, renderRequest, templateVersion1Published.version.toString())
+      hmppsAuth.verifyGrantTokenIsCalled(1)
+      sarDataSourceApi.verifyGetSubjectAccessRequestDataCalled()
+      sarDataSourceApi.verifyGetTemplateCalled()
+
+      assertLegacyFunctionalityServiceDataJsonFileDoesNotExistsInBucket(renderRequest)
+      assertUploadedHtmlMatchesExpected(
+        renderRequest,
+        getExpectedHtmlString("hmpps-test-service-migrated-template-v1"),
+      )
+      assertThatTemplateVersionIsPublished(templateVersion1Published.id)
+      assertThatTemplateVersionIsPending(templateVersion3Pending.id)
+      assertStoredTemplateVersionMatchesExpected(renderRequest, "v1")
 
       assertTemplateVersionHealthStatusEquals(
         serviceConfiguration = renderRequest.serviceConfiguration,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/repository/TemplateVersionRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/repository/TemplateVersionRepositoryTest.kt
@@ -46,36 +46,6 @@ class TemplateVersionRepositoryTest @Autowired constructor(
       category = ServiceCategory.PRISON,
     )
 
-    private val templateV1Published = TemplateVersion(
-      id = UUID.randomUUID(),
-      version = 1,
-      status = TemplateVersionStatus.PUBLISHED,
-      fileHash = templateHashV1,
-      createdAt = LocalDateTime.of(2025, 1, 1, 10, 0, 0),
-      serviceConfiguration = serviceConfiguration,
-    )
-
-    private val templateV2Published = TemplateVersion(
-      id = UUID.randomUUID(),
-      version = 1,
-      status = TemplateVersionStatus.PUBLISHED,
-      fileHash = templateHashV1,
-      createdAt = LocalDateTime.of(2025, 1, 2, 10, 0, 0),
-      serviceConfiguration = serviceConfiguration,
-    )
-
-    private val templateV3Pending = TemplateVersion(
-      id = UUID.randomUUID(),
-      version = 1,
-      status = TemplateVersionStatus.PENDING,
-      fileHash = templateHashV2,
-      createdAt = LocalDateTime.of(2025, 1, 2, 10, 5, 0),
-      serviceConfiguration = serviceConfiguration,
-    )
-
-
-
-
     val v1Published = TemplateVersion(
       id = UUID.randomUUID(),
       version = 1,
@@ -231,18 +201,18 @@ class TemplateVersionRepositoryTest @Autowired constructor(
   fun `should save template version`() {
     assertThat(templateVersionRepository.findAll()).isEmpty()
 
-    templateVersionRepository.save(templateV1Published)
+    templateVersionRepository.save(v1Published)
 
-    assertThat(templateVersionRepository.findByIdOrNull(templateV1Published.id)).isEqualTo(templateV1Published)
+    assertThat(templateVersionRepository.findByIdOrNull(v1Published.id)).isEqualTo(v1Published)
   }
 
   @Test
   fun `should delete template version`() {
-    templateVersionRepository.save(templateV1Published)
-    assertThat(templateVersionRepository.findByIdOrNull(templateV1Published.id)).isEqualTo(templateV1Published)
+    templateVersionRepository.save(v1Published)
+    assertThat(templateVersionRepository.findByIdOrNull(v1Published.id)).isEqualTo(v1Published)
 
-    templateVersionRepository.delete(templateV1Published)
-    assertThat(templateVersionRepository.findByIdOrNull(templateV1Published.id)).isNull()
+    templateVersionRepository.delete(v1Published)
+    assertThat(templateVersionRepository.findByIdOrNull(v1Published.id)).isNull()
   }
 
   @Nested
@@ -271,58 +241,6 @@ class TemplateVersionRepositoryTest @Autowired constructor(
   }
 
   @Nested
-  inner class FindLatestByServiceConfigurationId {
-
-    @Test
-    fun `should return null if no data exists`() {
-      val actual = templateVersionRepository.findLatestByServiceConfigurationId(serviceConfiguration.id)
-      assertThat(actual).isNull()
-    }
-
-    @Test
-    fun `should return latest template version if only 1 exists`() {
-      templateVersionRepository.save(templateV1Published)
-
-      val actual = templateVersionRepository.findLatestByServiceConfigurationId(serviceConfiguration.id)
-      assertThat(actual).isEqualTo(templateV1Published)
-    }
-
-    @Test
-    fun `should return expected template version when multiple versions exist`() {
-      templateVersionRepository.saveAll(listOf(templateV1Published, templateV2Published, templateV3Pending))
-
-      val actual = templateVersionRepository.findLatestByServiceConfigurationId(serviceConfiguration.id)
-      assertThat(actual).isEqualTo(templateV3Pending)
-    }
-
-    @Test
-    fun `should return value with higher version number when createdAt fields are equal`() {
-      // template V2 has the same createdAt value as V1
-      val v1 = TemplateVersion(
-        id = UUID.randomUUID(),
-        serviceConfiguration = serviceConfiguration,
-        status = TemplateVersionStatus.PUBLISHED,
-        version = 1,
-        createdAt = LocalDateTime.now(),
-        fileHash = templateHashV1,
-      )
-      val v2 = TemplateVersion(
-        id = UUID.randomUUID(),
-        serviceConfiguration = serviceConfiguration,
-        status = TemplateVersionStatus.PUBLISHED,
-        version = 2,
-        createdAt = v1.createdAt,
-        fileHash = templateHashV1,
-      )
-      templateVersionRepository.saveAll(listOf(v1, v2))
-
-      val actual = templateVersionRepository.findLatestByServiceConfigurationId(serviceConfiguration.id)
-
-      assertThat(actual).isEqualTo(v2)
-    }
-  }
-
-  @Nested
   inner class FindFirstByIdAndVersionAndFileHashAndStatusOrderByVersionDesc {
 
     @Test
@@ -339,16 +257,16 @@ class TemplateVersionRepositoryTest @Autowired constructor(
 
     @Test
     fun `should return expected value when records exist`() {
-      templateVersionRepository.saveAll(listOf(templateV1Published, templateV2Published, templateV3Pending))
+      templateVersionRepository.saveAll(listOf(v1Published, v2Published, v3Pending))
 
       val actual = templateVersionRepository.findFirstByIdAndVersionAndFileHashAndStatusOrderByVersionDesc(
-        id = templateV3Pending.id,
-        version = templateV3Pending.version,
-        fileHash = templateV3Pending.fileHash!!,
+        id = v3Pending.id,
+        version = v3Pending.version,
+        fileHash = v3Pending.fileHash!!,
         status = TemplateVersionStatus.PENDING,
       )
 
-      assertThat(actual).isEqualTo(templateV3Pending)
+      assertThat(actual).isEqualTo(v3Pending)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/repository/TemplateVersionRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/repository/TemplateVersionRepositoryTest.kt
@@ -4,6 +4,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest
 import org.springframework.data.repository.findByIdOrNull
@@ -20,45 +22,203 @@ class TemplateVersionRepositoryTest @Autowired constructor(
   val serviceConfigurationRepository: ServiceConfigurationRepository,
 ) {
 
-  private val templateHashV1 = "2340d53311fcf9aeaadeb6c90020d5ec77db229b342b0e0d088c7dce30eef24c"
-  private val templateHashV2 = "ab5dfcf36828754c50e61b440a7b30acef43956579e02230f2d29c837a42a4cc"
+  companion object {
 
-  private val serviceConfiguration = ServiceConfiguration(
-    id = UUID.randomUUID(),
-    serviceName = "example-service",
-    label = "Example",
-    enabled = true,
-    templateMigrated = true,
-    url = "https://example.com/",
-    category = ServiceCategory.PRISON,
-  )
+    data class FindLatestTestCase(
+      val desc: String,
+      val templateVersions: List<TemplateVersion>,
+      val serviceConfigId: UUID,
+      val expected: TemplateVersion?,
+    ) {
+      override fun toString(): String = desc
+    }
 
-  private val templateV1Published = TemplateVersion(
-    id = UUID.randomUUID(),
-    version = 1,
-    status = TemplateVersionStatus.PUBLISHED,
-    fileHash = templateHashV1,
-    createdAt = LocalDateTime.of(2025, 1, 1, 10, 0, 0),
-    serviceConfiguration = serviceConfiguration,
-  )
+    private val templateHashV1 = "2340d53311fcf9aeaadeb6c90020d5ec77db229b342b0e0d088c7dce30eef24c"
+    private val templateHashV2 = "ab5dfcf36828754c50e61b440a7b30acef43956579e02230f2d29c837a42a4cc"
 
-  private val templateV2Published = TemplateVersion(
-    id = UUID.randomUUID(),
-    version = 1,
-    status = TemplateVersionStatus.PUBLISHED,
-    fileHash = templateHashV1,
-    createdAt = LocalDateTime.of(2025, 1, 2, 10, 0, 0),
-    serviceConfiguration = serviceConfiguration,
-  )
+    private val serviceConfiguration = ServiceConfiguration(
+      id = UUID.randomUUID(),
+      serviceName = "example-service",
+      label = "Example",
+      enabled = true,
+      templateMigrated = true,
+      url = "https://example.com/",
+      category = ServiceCategory.PRISON,
+    )
 
-  private val templateV3Pending = TemplateVersion(
-    id = UUID.randomUUID(),
-    version = 1,
-    status = TemplateVersionStatus.PENDING,
-    fileHash = templateHashV2,
-    createdAt = LocalDateTime.of(2025, 1, 2, 10, 5, 0),
-    serviceConfiguration = serviceConfiguration,
-  )
+    private val templateV1Published = TemplateVersion(
+      id = UUID.randomUUID(),
+      version = 1,
+      status = TemplateVersionStatus.PUBLISHED,
+      fileHash = templateHashV1,
+      createdAt = LocalDateTime.of(2025, 1, 1, 10, 0, 0),
+      serviceConfiguration = serviceConfiguration,
+    )
+
+    private val templateV2Published = TemplateVersion(
+      id = UUID.randomUUID(),
+      version = 1,
+      status = TemplateVersionStatus.PUBLISHED,
+      fileHash = templateHashV1,
+      createdAt = LocalDateTime.of(2025, 1, 2, 10, 0, 0),
+      serviceConfiguration = serviceConfiguration,
+    )
+
+    private val templateV3Pending = TemplateVersion(
+      id = UUID.randomUUID(),
+      version = 1,
+      status = TemplateVersionStatus.PENDING,
+      fileHash = templateHashV2,
+      createdAt = LocalDateTime.of(2025, 1, 2, 10, 5, 0),
+      serviceConfiguration = serviceConfiguration,
+    )
+
+
+
+
+    val v1Published = TemplateVersion(
+      id = UUID.randomUUID(),
+      version = 1,
+      status = TemplateVersionStatus.PUBLISHED,
+      fileHash = "v1-published-hash",
+      createdAt = LocalDateTime.of(2025, 1, 1, 10, 1, 0),
+      serviceConfiguration = serviceConfiguration,
+    )
+
+    val v1Pending = TemplateVersion(
+      id = UUID.randomUUID(),
+      version = 1,
+      status = TemplateVersionStatus.PENDING,
+      fileHash = "v1-pending-hash",
+      createdAt = LocalDateTime.of(2025, 1, 1, 10, 1, 30),
+      serviceConfiguration = serviceConfiguration,
+    )
+
+    val v2Published = TemplateVersion(
+      id = UUID.randomUUID(),
+      version = 1,
+      status = TemplateVersionStatus.PUBLISHED,
+      fileHash = "v2-published-hash",
+      createdAt = LocalDateTime.of(2025, 1, 1, 10, 2, 0),
+      serviceConfiguration = serviceConfiguration,
+    )
+
+    val v2Pending = TemplateVersion(
+      id = serviceConfiguration.id,
+      version = 1,
+      status = TemplateVersionStatus.PUBLISHED,
+      fileHash = "v2-published-hash",
+      createdAt = LocalDateTime.of(2025, 1, 1, 10, 2, 30),
+      serviceConfiguration = serviceConfiguration,
+    )
+
+    val v3Pending = TemplateVersion(
+      id = UUID.randomUUID(),
+      version = 1,
+      status = TemplateVersionStatus.PENDING,
+      fileHash = "v3-pending-hash",
+      createdAt = LocalDateTime.of(2025, 1, 1, 10, 3, 0),
+      serviceConfiguration = serviceConfiguration,
+    )
+
+    @JvmStatic
+    fun findLatestPublishedTestCases() = listOf(
+      FindLatestTestCase(
+        desc = "no template versions exist",
+        templateVersions = emptyList(),
+        serviceConfigId = serviceConfiguration.id,
+        expected = null,
+      ),
+      FindLatestTestCase(
+        desc = "not version exist for service config id",
+        templateVersions = listOf(v1Published, v2Published),
+        serviceConfigId = UUID.randomUUID(),
+        expected = null,
+      ),
+      FindLatestTestCase(
+        desc = "a single template version exist",
+        templateVersions = listOf(v1Published),
+        serviceConfigId = serviceConfiguration.id,
+        expected = v1Published,
+      ),
+      FindLatestTestCase(
+        desc = "multiple published versions exist",
+        templateVersions = listOf(v1Published, v2Published),
+        serviceConfigId = serviceConfiguration.id,
+        expected = v2Published,
+      ),
+      FindLatestTestCase(
+        desc = "a published version exist and a pending version exists",
+        templateVersions = listOf(v1Published, v3Pending),
+        serviceConfigId = serviceConfiguration.id,
+        expected = v1Published,
+      ),
+      FindLatestTestCase(
+        desc = "multiple published versions exist and a pending version exists",
+        templateVersions = listOf(v1Published, v2Published, v3Pending),
+        serviceConfigId = serviceConfiguration.id,
+        expected = v2Published,
+      ),
+      FindLatestTestCase(
+        desc = "only a pending version exists",
+        templateVersions = listOf(v3Pending),
+        serviceConfigId = serviceConfiguration.id,
+        expected = null,
+      ),
+    )
+
+    @JvmStatic
+    fun findLatestPendingTestCases() = listOf(
+      FindLatestTestCase(
+        desc = "no template versions exist",
+        templateVersions = emptyList(),
+        serviceConfigId = serviceConfiguration.id,
+        expected = null,
+      ),
+      FindLatestTestCase(
+        desc = "only a published version exist",
+        templateVersions = listOf(v1Published),
+        serviceConfigId = serviceConfiguration.id,
+        expected = null,
+      ),
+      FindLatestTestCase(
+        desc = "a pending version exists created after latest published version",
+        templateVersions = listOf(v1Published, v1Pending),
+        serviceConfigId = serviceConfiguration.id,
+        expected = v1Pending,
+      ),
+      FindLatestTestCase(
+        desc = "multiple pending versions exist",
+        templateVersions = listOf(v1Published, v1Pending, v2Published, v3Pending),
+        serviceConfigId = serviceConfiguration.id,
+        expected = v3Pending,
+      ),
+      FindLatestTestCase(
+        desc = "latest pending has been superseded",
+        templateVersions = listOf(v1Published, v1Pending, v2Published),
+        serviceConfigId = serviceConfiguration.id,
+        expected = null,
+      ),
+      FindLatestTestCase(
+        desc = "there is no published version",
+        templateVersions = listOf(v1Pending),
+        serviceConfigId = serviceConfiguration.id,
+        expected = v1Pending,
+      ),
+      FindLatestTestCase(
+        desc = "multiple published versions",
+        templateVersions = listOf(v1Published, v2Published),
+        serviceConfigId = serviceConfiguration.id,
+        expected = null,
+      ),
+      FindLatestTestCase(
+        desc = "multiple pending versions no published versions",
+        templateVersions = listOf(v1Pending, v2Pending, v3Pending),
+        serviceConfigId = serviceConfiguration.id,
+        expected = v3Pending,
+      ),
+    )
+  }
 
   @BeforeEach
   fun setUp() {
@@ -83,6 +243,31 @@ class TemplateVersionRepositoryTest @Autowired constructor(
 
     templateVersionRepository.delete(templateV1Published)
     assertThat(templateVersionRepository.findByIdOrNull(templateV1Published.id)).isNull()
+  }
+
+  @Nested
+  inner class FindLatestByServiceConfigurationIdAndStatus {
+
+    @ParameterizedTest
+    @MethodSource("uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.repository.TemplateVersionRepositoryTest#findLatestPublishedTestCases")
+    fun `should return the expected published template value`(tc: FindLatestTestCase) {
+      templateVersionRepository.saveAll(tc.templateVersions)
+
+      val actual = templateVersionRepository.findLatestPublishedByServiceConfigurationId(tc.serviceConfigId)
+      assertThat(actual).isEqualTo(tc.expected)
+    }
+  }
+
+  @Nested
+  inner class FindLatestPendingByServiceConfigurationId {
+    @ParameterizedTest
+    @MethodSource("uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.repository.TemplateVersionRepositoryTest#findLatestPendingTestCases")
+    fun `should return the expected pending template value`(tc: FindLatestTestCase) {
+      templateVersionRepository.saveAll(tc.templateVersions)
+
+      val actual = templateVersionRepository.findLatestPendingByServiceConfigurationId(tc.serviceConfigId)
+      assertThat(actual).isEqualTo(tc.expected)
+    }
   }
 
   @Nested

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/template/TemplateVersionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/template/TemplateVersionServiceTest.kt
@@ -363,7 +363,6 @@ class TemplateVersionServiceTest : TemplateVersionServiceTestFixture() {
       verifyNoMoreInteractions(dynamicServicesClient, templateVersionRepository, serviceConfigurationService)
     }
 
-
     @Test
     fun `should succeed when service template matches PENDING template created after a previous PUBLISHED template`() {
       val saveCaptor = argumentCaptor<TemplateVersion>()
@@ -375,7 +374,7 @@ class TemplateVersionServiceTest : TemplateVersionServiceTestFixture() {
       )
       templateVersionRepository.mockFindLatestPublishedByServiceConfigurationId(returnValue = v1Published)
       templateVersionRepository.mockFindLatestPendingByServiceConfigurationId(returnValue = v2Pending)
-      templateVersionRepository. mockFindFirstByIdAndVersionAndFileHashAndStatusOrderByVersionDesc(
+      templateVersionRepository.mockFindFirstByIdAndVersionAndFileHashAndStatusOrderByVersionDesc(
         id = v2Pending.id,
         version = 2,
         status = TemplateVersionStatus.PENDING,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/template/TemplateVersionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/template/TemplateVersionServiceTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.config.Rend
 import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.exception.ErrorCode
 import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.exception.SubjectAccessRequestException
 import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.exception.SubjectAccessRequestRetryExhaustedException
+import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.models.HealthStatusType
 import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.models.TemplateVersion
 import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.models.TemplateVersionStatus
 
@@ -28,8 +29,8 @@ class TemplateVersionServiceTest : TemplateVersionServiceTestFixture() {
 
     @Test
     fun `should return expected SHA-256 value`() {
-      assertThat(templateVersionService.getSha256HashValue(publishedTemplateBody))
-        .isEqualTo(publishedTemplateHash)
+      assertThat(templateVersionService.getSha256HashValue(v1PublishedBody))
+        .isEqualTo(v1PublishedHash)
     }
   }
 
@@ -77,7 +78,7 @@ class TemplateVersionServiceTest : TemplateVersionServiceTestFixture() {
     @Test
     fun `should throw exception when service configuration does not exist`() {
       dynamicServicesClient.mockGetServiceTemplate(
-        returnValue = ResponseEntity.ok(publishedTemplateBody),
+        returnValue = ResponseEntity.ok(v1PublishedBody),
       )
       serviceConfigurationService.mockGetConfigurationById(
         returnValue = null,
@@ -107,12 +108,13 @@ class TemplateVersionServiceTest : TemplateVersionServiceTestFixture() {
     @Test
     fun `should throw exception when service template does not match any registered template versions`() {
       dynamicServicesClient.mockGetServiceTemplate(
-        returnValue = ResponseEntity.ok(publishedTemplateBody),
+        returnValue = ResponseEntity.ok(v3UnregisteredBody),
       )
       serviceConfigurationService.mockGetConfigurationById(
         returnValue = serviceConfig,
       )
-      templateVersionRepository.mockFindLatestByServiceConfigurationId(returnValue = null)
+      templateVersionRepository.mockFindLatestPublishedByServiceConfigurationId(returnValue = v1Published)
+      templateVersionRepository.mockFindLatestPendingByServiceConfigurationId(returnValue = v2Pending)
 
       val actual = assertThrows<SubjectAccessRequestException> {
         templateVersionService.getTemplate(renderRequest)
@@ -124,20 +126,70 @@ class TemplateVersionServiceTest : TemplateVersionServiceTestFixture() {
         errorCode = ErrorCode.SERVICE_TEMPLATE_HASH_MISMATCH,
         params = mapOf(
           "serviceConfigurationId" to serviceConfig.id,
-          "serviceTemplateHash" to publishedTemplateHash,
+          "serviceTemplateHash" to v3UnregisteredHash,
         ),
       )
 
       dynamicServicesClient.verifyGetServiceTemplateIsCalled(times = 1)
       serviceConfigurationService.verifyGetServiceConfigurationIsCalled(times = 1)
-      templateVersionRepository.verifyFindLatestByServiceConfigurationIdIsCalled(times = 1)
+      templateVersionRepository.verifyFindLatestPublishedByServiceConfigurationIdIsCalled(times = 1)
+      templateVersionRepository.verifyFindLatestPendingByServiceConfigurationIdIsCalled(times = 1)
+      templateVersionHealthService.verifyUpdateHealthStatusIfChangedIsCalled(
+        times = 1,
+        serviceConfiguration = serviceConfig,
+        HealthStatusType.UNHEALTHY,
+      )
       verifyNoMoreInteractions(dynamicServicesClient, templateVersionRepository, serviceConfigurationService)
       verifyTelemetryEventsCaptures(
         event = SERVICE_TEMPLATE_HASH_MISMATCH,
         subjectAccessRequestId = renderRequest.id,
         "serviceName" to serviceConfig.serviceName,
         "serviceConfigurationId" to serviceConfig.id.toString(),
-        "serviceTemplateHash" to publishedTemplateHash,
+        "serviceTemplateHash" to v3UnregisteredHash,
+      )
+    }
+
+    @Test
+    fun `should throw exception when no template version exists for status PENDING or PUBLISHED`() {
+      dynamicServicesClient.mockGetServiceTemplate(
+        returnValue = ResponseEntity.ok(v3UnregisteredBody),
+      )
+      serviceConfigurationService.mockGetConfigurationById(
+        returnValue = serviceConfig,
+      )
+      templateVersionRepository.mockFindLatestPublishedByServiceConfigurationId(returnValue = null)
+      templateVersionRepository.mockFindLatestPendingByServiceConfigurationId(returnValue = null)
+
+      val actual = assertThrows<SubjectAccessRequestException> {
+        templateVersionService.getTemplate(renderRequest)
+      }
+
+      assertIsExpectedException(
+        actual = actual,
+        message = "service template file hash does not match registered template versions",
+        errorCode = ErrorCode.SERVICE_TEMPLATE_HASH_MISMATCH,
+        params = mapOf(
+          "serviceConfigurationId" to serviceConfig.id,
+          "serviceTemplateHash" to v3UnregisteredHash,
+        ),
+      )
+
+      dynamicServicesClient.verifyGetServiceTemplateIsCalled(times = 1)
+      serviceConfigurationService.verifyGetServiceConfigurationIsCalled(times = 1)
+      templateVersionRepository.verifyFindLatestPublishedByServiceConfigurationIdIsCalled(times = 1)
+      templateVersionRepository.verifyFindLatestPendingByServiceConfigurationIdIsCalled(times = 1)
+      templateVersionHealthService.verifyUpdateHealthStatusIfChangedIsCalled(
+        times = 1,
+        serviceConfiguration = serviceConfig,
+        HealthStatusType.UNHEALTHY,
+      )
+      verifyNoMoreInteractions(dynamicServicesClient, templateVersionRepository, serviceConfigurationService)
+      verifyTelemetryEventsCaptures(
+        event = SERVICE_TEMPLATE_HASH_MISMATCH,
+        subjectAccessRequestId = renderRequest.id,
+        "serviceName" to serviceConfig.serviceName,
+        "serviceConfigurationId" to serviceConfig.id.toString(),
+        "serviceTemplateHash" to v3UnregisteredHash,
       )
     }
 
@@ -145,14 +197,15 @@ class TemplateVersionServiceTest : TemplateVersionServiceTestFixture() {
     fun `should throw exception if error is thrown when updating a template status from PENDING to PUBLISHED`() {
       val saveCaptor = argumentCaptor<TemplateVersion>()
 
-      dynamicServicesClient.mockGetServiceTemplate(returnValue = ResponseEntity.ok(pendingTemplateBody))
+      dynamicServicesClient.mockGetServiceTemplate(returnValue = ResponseEntity.ok(v2PendingBody))
       serviceConfigurationService.mockGetConfigurationById(returnValue = serviceConfig)
-      templateVersionRepository.mockFindLatestByServiceConfigurationId(returnValue = pendingTemplateVersion)
+      templateVersionRepository.mockFindLatestPublishedByServiceConfigurationId(returnValue = null)
+      templateVersionRepository.mockFindLatestPendingByServiceConfigurationId(returnValue = v2Pending)
       templateVersionRepository.mockFindFirstByIdAndVersionAndFileHashAndStatusOrderByVersionDesc(
-        id = pendingTemplateVersion.id,
-        version = pendingTemplateVersion.version,
-        fileHash = pendingTemplateHash,
-        returnValue = pendingTemplateVersion,
+        id = v2Pending.id,
+        version = v2Pending.version,
+        fileHash = v2PendingHash,
+        returnValue = v2Pending,
       )
 
       templateVersionRepository.mockSaveAndFlushException()
@@ -167,35 +220,36 @@ class TemplateVersionServiceTest : TemplateVersionServiceTestFixture() {
         errorCode = ErrorCode.SERVICE_TEMPLATE_PUBLISH_FAILURE,
         params = mapOf(
           "serviceName" to serviceConfig.serviceName,
-          "version" to pendingTemplateVersion.version,
-          "templateVersionId" to pendingTemplateVersion.id,
+          "version" to v2Pending.version,
+          "templateVersionId" to v2Pending.id,
         ),
       )
 
       dynamicServicesClient.verifyGetServiceTemplateIsCalled(times = 1)
       serviceConfigurationService.verifyGetServiceConfigurationIsCalled(times = 1)
-      templateVersionRepository.verifyFindLatestByServiceConfigurationIdIsCalled(times = 1)
+      templateVersionRepository.verifyFindLatestPublishedByServiceConfigurationIdIsCalled(times = 1)
+      templateVersionRepository.verifyFindLatestPendingByServiceConfigurationIdIsCalled(times = 1)
       templateVersionRepository.verifyFindFirstByIdAndVersionAndFileHashAndStatusOrderByVersionDescIsCalled(
         times = 1,
-        templateVersionId = pendingTemplateVersion.id,
+        templateVersionId = v2Pending.id,
         version = 2,
         status = TemplateVersionStatus.PENDING,
-        fileHash = pendingTemplateHash,
+        fileHash = v2PendingHash,
       )
       templateVersionRepository.verifySaveAndFlushIsCalled(
         times = 1,
-        templateVersionId = pendingTemplateVersion.id,
+        templateVersionId = v2Pending.id,
         version = 2,
         status = TemplateVersionStatus.PUBLISHED,
-        fileHash = pendingTemplateHash,
+        fileHash = v2PendingHash,
         captor = saveCaptor,
       )
       verifyTelemetryEventsCaptures(
         event = SERVICE_TEMPLATE_PUBLISH_ERROR,
         subjectAccessRequestId = renderRequest.id,
         "serviceName" to serviceConfig.serviceName,
-        "version" to pendingTemplateVersion.version.toString(),
-        "templateVersionId" to pendingTemplateVersion.id.toString(),
+        "version" to v2Pending.version.toString(),
+        "templateVersionId" to v2Pending.id.toString(),
       )
       verifyNoMoreInteractions(dynamicServicesClient, templateVersionRepository, serviceConfigurationService)
     }
@@ -207,18 +261,24 @@ class TemplateVersionServiceTest : TemplateVersionServiceTestFixture() {
     @Test
     fun `should succeed when service template hash matches PUBLISHED template version hash`() {
       dynamicServicesClient.mockGetServiceTemplate(
-        returnValue = ResponseEntity.ok(publishedTemplateBody),
+        returnValue = ResponseEntity.ok(v1PublishedBody),
       )
       serviceConfigurationService.mockGetConfigurationById(
         returnValue = serviceConfig,
       )
-      templateVersionRepository.mockFindLatestByServiceConfigurationId(returnValue = publishedTemplateVersion)
+      templateVersionRepository.mockFindLatestPublishedByServiceConfigurationId(returnValue = v1Published)
 
       templateVersionService.getTemplate(renderRequest)
 
       dynamicServicesClient.verifyGetServiceTemplateIsCalled(times = 1)
       serviceConfigurationService.verifyGetServiceConfigurationIsCalled(times = 1)
-      templateVersionRepository.verifyFindLatestByServiceConfigurationIdIsCalled(times = 1)
+      templateVersionRepository.verifyFindLatestPublishedByServiceConfigurationIdIsCalled(times = 1)
+      templateVersionRepository.verifyFindLatestPendingByServiceConfigurationIdNeverCalled()
+      templateVersionHealthService.verifyUpdateHealthStatusIfChangedIsCalled(
+        times = 1,
+        serviceConfiguration = serviceConfig,
+        HealthStatusType.HEALTHY,
+      )
 
       verifyNoMoreInteractions(dynamicServicesClient, templateVersionRepository, serviceConfigurationService)
     }
@@ -228,44 +288,46 @@ class TemplateVersionServiceTest : TemplateVersionServiceTestFixture() {
       val saveCaptor = argumentCaptor<TemplateVersion>()
 
       dynamicServicesClient.mockGetServiceTemplate(
-        returnValue = ResponseEntity.ok(pendingTemplateBody),
+        returnValue = ResponseEntity.ok(v2PendingBody),
       )
       serviceConfigurationService.mockGetConfigurationById(
         returnValue = serviceConfig,
       )
-      templateVersionRepository.mockFindLatestByServiceConfigurationId(returnValue = pendingTemplateVersion)
+      templateVersionRepository.mockFindLatestPublishedByServiceConfigurationId(returnValue = null)
+      templateVersionRepository.mockFindLatestPendingByServiceConfigurationId(returnValue = v2Pending)
       templateVersionRepository.mockFindFirstByIdAndVersionAndFileHashAndStatusOrderByVersionDesc(
-        id = pendingTemplateVersion.id,
+        id = v2Pending.id,
         version = 2,
-        fileHash = pendingTemplateHash,
+        fileHash = v2PendingHash,
         status = TemplateVersionStatus.PENDING,
-        returnValue = pendingTemplateVersion,
+        returnValue = v2Pending,
       )
 
       templateVersionService.getTemplate(renderRequest)
 
       dynamicServicesClient.verifyGetServiceTemplateIsCalled(times = 1)
       serviceConfigurationService.verifyGetServiceConfigurationIsCalled(times = 1)
-      templateVersionRepository.verifyFindLatestByServiceConfigurationIdIsCalled(times = 1)
+      templateVersionRepository.verifyFindLatestPublishedByServiceConfigurationIdIsCalled(times = 1)
+      templateVersionRepository.verifyFindLatestPendingByServiceConfigurationIdIsCalled(times = 1)
       templateVersionRepository.mockFindFirstByIdAndVersionAndFileHashAndStatusOrderByVersionDesc(
-        id = pendingTemplateVersion.id,
-        version = pendingTemplateVersion.version,
-        fileHash = pendingTemplateHash,
-        returnValue = pendingTemplateVersion,
+        id = v2Pending.id,
+        version = v2Pending.version,
+        fileHash = v2PendingHash,
+        returnValue = v2Pending,
       )
       templateVersionRepository.verifyFindFirstByIdAndVersionAndFileHashAndStatusOrderByVersionDescIsCalled(
         times = 1,
-        templateVersionId = pendingTemplateVersion.id,
+        templateVersionId = v2Pending.id,
         version = 2,
         status = TemplateVersionStatus.PENDING,
-        fileHash = pendingTemplateHash,
+        fileHash = v2PendingHash,
       )
       templateVersionRepository.verifySaveAndFlushIsCalled(
         times = 1,
-        templateVersionId = pendingTemplateVersion.id,
+        templateVersionId = v2Pending.id,
         version = 2,
         status = TemplateVersionStatus.PUBLISHED,
-        fileHash = pendingTemplateHash,
+        fileHash = v2PendingHash,
         captor = saveCaptor,
       )
 
@@ -273,10 +335,84 @@ class TemplateVersionServiceTest : TemplateVersionServiceTestFixture() {
         event = SERVICE_TEMPLATE_PUBLISHED,
         subjectAccessRequestId = renderRequest.id,
         "serviceName" to serviceConfig.serviceName,
-        "version" to pendingTemplateVersion.version.toString(),
+        "version" to v2Pending.version.toString(),
       )
 
       verifyNoMoreInteractions(templateVersionRepository, serviceConfigurationService)
+    }
+
+    @Test
+    fun `should succeed when service template matches PUBLISHED template and there is a PENDING template created after the PUBLISHED template`() {
+      dynamicServicesClient.mockGetServiceTemplate(
+        returnValue = ResponseEntity.ok(v1PublishedBody),
+      )
+      serviceConfigurationService.mockGetConfigurationById(
+        returnValue = serviceConfig,
+      )
+      templateVersionRepository.mockFindLatestPublishedByServiceConfigurationId(returnValue = v1Published)
+
+      val actual = templateVersionService.getTemplate(renderRequest)
+      assertThat(actual).isNotNull
+      assertThat(actual).isEqualTo(TemplateDetails(version = "1", body = v1PublishedBody))
+
+      dynamicServicesClient.verifyGetServiceTemplateIsCalled(times = 1)
+      serviceConfigurationService.verifyGetServiceConfigurationIsCalled(times = 1)
+      templateVersionRepository.verifyFindLatestPublishedByServiceConfigurationIdIsCalled(times = 1)
+      templateVersionRepository.verifyFindLatestPendingByServiceConfigurationIdNeverCalled()
+
+      verifyNoMoreInteractions(dynamicServicesClient, templateVersionRepository, serviceConfigurationService)
+    }
+
+
+    @Test
+    fun `should succeed when service template matches PENDING template created after a previous PUBLISHED template`() {
+      val saveCaptor = argumentCaptor<TemplateVersion>()
+      dynamicServicesClient.mockGetServiceTemplate(
+        returnValue = ResponseEntity.ok(v2PendingBody),
+      )
+      serviceConfigurationService.mockGetConfigurationById(
+        returnValue = serviceConfig,
+      )
+      templateVersionRepository.mockFindLatestPublishedByServiceConfigurationId(returnValue = v1Published)
+      templateVersionRepository.mockFindLatestPendingByServiceConfigurationId(returnValue = v2Pending)
+      templateVersionRepository. mockFindFirstByIdAndVersionAndFileHashAndStatusOrderByVersionDesc(
+        id = v2Pending.id,
+        version = 2,
+        status = TemplateVersionStatus.PENDING,
+        fileHash = v2PendingHash,
+        returnValue = v2Pending,
+      )
+
+      val actual = templateVersionService.getTemplate(renderRequest)
+      assertThat(actual).isNotNull
+      assertThat(actual).isEqualTo(TemplateDetails(version = "2", body = v2PendingBody))
+
+      dynamicServicesClient.verifyGetServiceTemplateIsCalled(times = 1)
+      serviceConfigurationService.verifyGetServiceConfigurationIsCalled(times = 1)
+      templateVersionRepository.verifyFindLatestPublishedByServiceConfigurationIdIsCalled(times = 1)
+      templateVersionRepository.verifyFindLatestPendingByServiceConfigurationIdIsCalled(times = 1)
+      templateVersionRepository.verifyFindFirstByIdAndVersionAndFileHashAndStatusOrderByVersionDescIsCalled(
+        times = 1,
+        templateVersionId = v2Pending.id,
+        version = 2,
+        status = TemplateVersionStatus.PENDING,
+        fileHash = v2PendingHash,
+      )
+      templateVersionRepository.verifySaveAndFlushIsCalled(
+        times = 1,
+        templateVersionId = v2Pending.id,
+        version = 2,
+        status = TemplateVersionStatus.PUBLISHED,
+        fileHash = v2PendingHash,
+        captor = saveCaptor,
+      )
+      templateVersionHealthService.verifyUpdateHealthStatusIfChangedIsCalled(
+        times = 1,
+        serviceConfiguration = serviceConfig,
+        HealthStatusType.HEALTHY,
+      )
+
+      verifyNoMoreInteractions(dynamicServicesClient, templateVersionRepository, serviceConfigurationService)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/template/TemplateVersionServiceTestFixture.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/template/TemplateVersionServiceTestFixture.kt
@@ -8,6 +8,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -16,6 +17,7 @@ import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.client.Dyna
 import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.config.RenderEvent
 import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.exception.ErrorCode
 import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.exception.SubjectAccessRequestException
+import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.models.HealthStatusType
 import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.models.ServiceCategory
 import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.models.ServiceConfiguration
 import uk.gov.justice.digital.hmpps.subjectaccessrequesthtmlrenderer.models.TemplateVersion
@@ -35,11 +37,14 @@ abstract class TemplateVersionServiceTestFixture {
   protected val templateVersionHealthService: TemplateVersionHealthService = mock()
   protected val telemetryClient: TelemetryClient = mock()
 
-  protected val publishedTemplateBody = "<h1>HMPPS Test Service</h1>"
-  protected val publishedTemplateHash = "2340d53311fcf9aeaadeb6c90020d5ec77db229b342b0e0d088c7dce30eef24c"
+  protected val v1PublishedBody = "<h1>HMPPS Test Service</h1>"
+  protected val v1PublishedHash = "2340d53311fcf9aeaadeb6c90020d5ec77db229b342b0e0d088c7dce30eef24c"
 
-  protected val pendingTemplateBody = "<h1>HMPPS Test Service V2</h1>"
-  protected val pendingTemplateHash = "ab5dfcf36828754c50e61b440a7b30acef43956579e02230f2d29c837a42a4cc"
+  protected val v2PendingBody = "<h1>HMPPS Test Service V2</h1>"
+  protected val v2PendingHash = "ab5dfcf36828754c50e61b440a7b30acef43956579e02230f2d29c837a42a4cc"
+
+  protected val v3UnregisteredBody = "<h1>HMPPS Test Service V3 not registered</h1>"
+  protected val v3UnregisteredHash = "005e3d7b859fc308cded9f017ed34fc25bde05e298a74b4a5023e096a9b45058"
 
   protected val telemetryEventTypeCaptor = argumentCaptor<String>()
   protected val telemetryPropertiesCaptor = argumentCaptor<Map<String, String>>()
@@ -55,24 +60,24 @@ abstract class TemplateVersionServiceTestFixture {
     category = ServiceCategory.PRISON,
   )
 
-  protected val publishedTemplateVersion = TemplateVersion(
+  protected val v1Published = TemplateVersion(
     id = UUID.randomUUID(),
     serviceConfiguration = serviceConfig,
     status = TemplateVersionStatus.PUBLISHED,
     version = 1,
     createdAt = LocalDateTime.of(2025, 10, 11, 0, 0, 0),
     publishedAt = LocalDateTime.of(2025, 10, 11, 10, 0, 0),
-    fileHash = publishedTemplateHash,
+    fileHash = v1PublishedHash,
   )
 
-  protected val pendingTemplateVersion = TemplateVersion(
+  protected val v2Pending = TemplateVersion(
     id = UUID.randomUUID(),
     serviceConfiguration = serviceConfig,
     status = TemplateVersionStatus.PENDING,
     version = 2,
     createdAt = LocalDateTime.of(2025, 11, 11, 0, 0, 0),
-    publishedAt = LocalDateTime.of(2025, 11, 11, 10, 0, 0),
-    fileHash = pendingTemplateHash,
+    publishedAt = null,
+    fileHash = v2PendingHash,
   )
 
   protected val renderRequest = RenderRequest(
@@ -125,6 +130,48 @@ abstract class TemplateVersionServiceTestFixture {
     serviceConfigurationId: UUID = serviceConfig.id,
   ) {
     verify(this, times(times)).findLatestByServiceConfigurationId(serviceConfigurationId)
+  }
+
+  protected fun TemplateVersionRepository.mockFindLatestPublishedByServiceConfigurationId(
+    returnValue: TemplateVersion?
+  ) {
+    whenever(this.findLatestPublishedByServiceConfigurationId(serviceConfig.id))
+      .thenReturn(returnValue)
+  }
+
+  protected fun TemplateVersionRepository.verifyFindLatestPublishedByServiceConfigurationIdIsCalled(
+    times: Int = 1,
+    serviceConfigurationId: UUID = serviceConfig.id,
+  ) {
+    verify(this, times(times))
+      .findLatestPublishedByServiceConfigurationId(serviceConfigurationId)
+  }
+
+  protected fun TemplateVersionRepository.mockFindLatestPendingByServiceConfigurationId(
+    returnValue: TemplateVersion?
+  ) {
+    whenever(this.findLatestPendingByServiceConfigurationId(serviceConfig.id))
+      .thenReturn(returnValue)
+  }
+
+  protected fun TemplateVersionRepository.verifyFindLatestPendingByServiceConfigurationIdIsCalled(
+    times: Int = 1,
+    serviceConfigurationId: UUID = serviceConfig.id,
+  ) {
+    verify(this, times(times))
+      .findLatestPendingByServiceConfigurationId(serviceConfigurationId)
+  }
+
+  protected fun TemplateVersionRepository.verifyFindLatestPendingByServiceConfigurationIdNeverCalled() {
+    verify(this, never()).findLatestPendingByServiceConfigurationId(serviceConfig.id)
+  }
+
+  protected fun TemplateVersionHealthService.verifyUpdateHealthStatusIfChangedIsCalled(
+    times: Int = 1,
+    serviceConfiguration: ServiceConfiguration,
+    status: HealthStatusType,
+  ) {
+    verify(this, times(times)).updateHealthStatusIfChanged(serviceConfiguration, status)
   }
 
   protected fun TemplateVersionRepository.mockFindFirstByIdAndVersionAndFileHashAndStatusOrderByVersionDesc(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/template/TemplateVersionServiceTestFixture.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/subjectaccessrequesthtmlrenderer/template/TemplateVersionServiceTestFixture.kt
@@ -119,21 +119,8 @@ abstract class TemplateVersionServiceTestFixture {
     )
   }
 
-  protected fun TemplateVersionRepository.mockFindLatestByServiceConfigurationId(
-    returnValue: TemplateVersion?,
-  ) {
-    whenever(this.findLatestByServiceConfigurationId(serviceConfig.id)).thenReturn(returnValue)
-  }
-
-  protected fun TemplateVersionRepository.verifyFindLatestByServiceConfigurationIdIsCalled(
-    times: Int = 1,
-    serviceConfigurationId: UUID = serviceConfig.id,
-  ) {
-    verify(this, times(times)).findLatestByServiceConfigurationId(serviceConfigurationId)
-  }
-
   protected fun TemplateVersionRepository.mockFindLatestPublishedByServiceConfigurationId(
-    returnValue: TemplateVersion?
+    returnValue: TemplateVersion?,
   ) {
     whenever(this.findLatestPublishedByServiceConfigurationId(serviceConfig.id))
       .thenReturn(returnValue)
@@ -148,7 +135,7 @@ abstract class TemplateVersionServiceTestFixture {
   }
 
   protected fun TemplateVersionRepository.mockFindLatestPendingByServiceConfigurationId(
-    returnValue: TemplateVersion?
+    returnValue: TemplateVersion?,
   ) {
     whenever(this.findLatestPendingByServiceConfigurationId(serviceConfig.id))
       .thenReturn(returnValue)

--- a/src/test/resources/integration-tests/reference-html-stubs/hmpps-test-service-migrated-template-v3-expected.html
+++ b/src/test/resources/integration-tests/reference-html-stubs/hmpps-test-service-migrated-template-v3-expected.html
@@ -1,0 +1,232 @@
+<style>
+    * {
+        font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
+        font-size: 12pt;
+        color: #0b0c0c;
+    }
+    /* --- HEADINGS --- */
+
+    .title {
+        font-size: 20pt;
+        text-align: center;
+    }
+
+    h1, h2, h3 {
+        color: #0b0c0c;
+        font-weight: 700;
+        display: block;
+        margin-top: 0;
+        margin-inline-start: 0;
+        margin-inline-end: 0;
+    }
+
+    h1 {
+        font-size: 18pt;
+        line-height: 1.09375;
+        margin-top: 20px;
+        margin-bottom: 10px;
+        margin-block-start: 0.67em;
+        margin-block-end: 0.67em;
+    }
+
+    h2 {
+        font-size: 17pt;
+        line-height: 1.0416666667;
+        margin-top: 15px;
+        margin-bottom: 5px;
+        margin-block-start: 0.83em;
+        margin-block-end: 0.83em;
+    }
+
+    h3 {
+        font-size: 16pt;
+        line-height: 1.0416666667;
+        margin-top: 15px;
+        margin-bottom: 5px;
+        margin-block-start: 0.83em;
+        margin-block-end: 0.83em;
+    }
+
+    h4 {
+        font-size: 15pt;
+        line-height: 1.0416666667;
+        margin-top: 15px;
+        margin-bottom: 5px;
+        margin-block-start: 0.83em;
+        margin-block-end: 0.83em;
+    }
+
+    h5 {
+        font-size: 14pt;
+        line-height: 1.0416666667;
+        margin-top: 15px;
+        margin-bottom: 5px;
+        margin-block-start: 0.83em;
+        margin-block-end: 0.83em;
+    }
+
+    /* --- SUMMARY LIST --- */
+
+    table.summary-list {
+        display: table;
+        width: 700px;
+        table-layout: fixed;
+        border-collapse: collapse;
+        margin: 0 0 5px;
+        margin-block-start: 1em;
+        margin-block-end: 1em;
+        margin-inline-start: 0;
+        margin-inline-end: 0;
+    }
+
+    table.summary-list tr {
+        display: table-row;
+        margin: 0 0 20px;
+    }
+
+    table.summary-list tr td {
+        border-bottom: 1px solid #b1b4b6;
+        /*margin-bottom: 5px;*/
+        overflow-wrap: break-word;
+        display: table-cell;
+        /*padding-top: 2px;*/
+        /*padding-bottom: 2px;*/
+        /*padding-right: 0;*/
+        margin-inline-start: 40px;
+        width: 70%;
+        table-layout: fixed;
+        border-collapse: collapse;
+        line-height: 1.25;
+        font-weight: 400;
+        white-space: normal;
+        vertical-align: top;
+    }
+
+    table.summary-list tr td:first-child {
+        font-size: 12pt;
+        width: 30%;
+        font-weight: 700;
+        padding-right: 20px;
+        vertical-align: top;
+    }
+
+    /* --- DATA TABLE --- */
+
+    table.data-table {
+        display: table;
+        width: 700px;
+        table-layout: fixed;
+        border-collapse: collapse;
+        margin: 0 0 5px;
+        margin-block-start: 1em;
+        margin-block-end: 1em;
+        margin-inline-start: 0;
+        margin-inline-end: 0;
+    }
+
+    table.data-table tr {
+        display: table-row;
+        margin: 0 0 20px;
+    }
+
+    table.data-table tr td {
+        border-bottom: 1px solid #b1b4b6;
+        margin-bottom: 5px;
+        overflow-wrap: break-word;
+        display: table-cell;
+        padding-top: 2px;
+        padding-bottom: 2px;
+        padding-right: 0;
+        margin-inline-start: 40px;
+        table-layout: fixed;
+        border-collapse: collapse;
+        line-height: 1.25;
+        font-weight: 400;
+        white-space: pre-wrap;
+        vertical-align: top;
+    }
+
+    table.data-table tr:first-child td {
+        font-size: 12pt;
+        width: 30%;
+        font-weight: 700;
+        padding-right: 20px;
+        border-bottom: none;
+        vertical-align: top;
+    }
+
+    table.data-table tr td.data-column-5 { width: 5% }
+    table.data-table tr td.data-column-10 { width: 10% }
+    table.data-table tr td.data-column-15 { width: 15% }
+    table.data-table tr td.data-column-20 { width: 20% }
+    table.data-table tr td.data-column-25 { width: 25% }
+    table.data-table tr td.data-column-30 { width: 30% }
+    table.data-table tr td.data-column-35 { width: 35% }
+    table.data-table tr td.data-column-40 { width: 40% }
+    table.data-table tr td.data-column-45 { width: 45% }
+    table.data-table tr td.data-column-50 { width: 50% }
+    table.data-table tr td.data-column-55 { width: 55% }
+    table.data-table tr td.data-column-60 { width: 60% }
+    table.data-table tr td.data-column-65 { width: 65% }
+    table.data-table tr td.data-column-70 { width: 70% }
+    table.data-table tr td.data-column-75 { width: 75% }
+    table.data-table tr td.data-column-80 { width: 80% }
+    table.data-table tr td.data-column-85 { width: 85% }
+    table.data-table tr td.data-column-90 { width: 90% }
+    table.data-table tr td.data-column-95 { width: 95% }
+
+    table tr td.data-column-5 { width: 5% }
+    table tr td.data-column-10 { width: 10% }
+    table tr td.data-column-15 { width: 15% }
+    table tr td.data-column-20 { width: 20% }
+    table tr td.data-column-25 { width: 25% }
+    table tr td.data-column-30 { width: 30% }
+    table tr td.data-column-35 { width: 35% }
+    table tr td.data-column-40 { width: 40% }
+    table tr td.data-column-45 { width: 45% }
+    table tr td.data-column-50 { width: 50% }
+    table tr td.data-column-55 { width: 55% }
+    table tr td.data-column-60 { width: 60% }
+    table tr td.data-column-65 { width: 65% }
+    table tr td.data-column-70 { width: 70% }
+    table tr td.data-column-75 { width: 75% }
+    table tr td.data-column-80 { width: 80% }
+    table tr td.data-column-85 { width: 85% }
+    table tr td.data-column-90 { width: 90% }
+    table tr td.data-column-95 { width: 95% }
+
+    table.summary-list tr td.data-column-5 { width: 5% }
+    table.summary-list tr td.data-column-10 { width: 10% }
+    table.summary-list tr td.data-column-15 { width: 15% }
+    table.summary-list tr td.data-column-20 { width: 20% }
+    table.summary-list tr td.data-column-25 { width: 25% }
+    table.summary-list tr td.data-column-30 { width: 30% }
+    table.summary-list tr td.data-column-35 { width: 35% }
+    table.summary-list tr td.data-column-40 { width: 40% }
+    table.summary-list tr td.data-column-45 { width: 45% }
+    table.summary-list tr td.data-column-50 { width: 50% }
+    table.summary-list tr td.data-column-55 { width: 55% }
+    table.summary-list tr td.data-column-60 { width: 60% }
+    table.summary-list tr td.data-column-65 { width: 65% }
+    table.summary-list tr td.data-column-70 { width: 70% }
+    table.summary-list tr td.data-column-75 { width: 75% }
+    table.summary-list tr td.data-column-80 { width: 80% }
+    table.summary-list tr td.data-column-85 { width: 85% }
+    table.summary-list tr td.data-column-90 { width: 90% }
+    table.summary-list tr td.data-column-95 { width: 95% }
+
+    ul {
+        padding: 0 0 0 10px;
+    }
+
+</style>
+
+<h1>HMPPS Test Service Template Migrated: V3</h1>
+
+    <h2>Migrated Template</h2>
+    <table class="summary-list">
+        <tr><td>ID</td><td>1234567890</td></tr>
+        <tr><td>Created</td><td>14 November 2025, 10:10:10 am</td></tr>
+        <tr><td>Updated By</td><td>SIMPSON</td></tr>
+        <tr><td>Prison name</td><td>Springfield Penitentiary (SPT)</td></tr>
+    </table>

--- a/src/test/resources/templates/hmpps-test-service-migrated-template-v3.mustache
+++ b/src/test/resources/templates/hmpps-test-service-migrated-template-v3.mustache
@@ -1,0 +1,10 @@
+<h1>HMPPS Test Service Template Migrated: V3</h1>
+{{#.}}
+    <h2>Migrated Template</h2>
+    <table class="summary-list">
+        <tr><td>ID</td><td>{{ optionalValue id }}</td></tr>
+        <tr><td>Created</td><td>{{ optionalValue (formatDate created) }}</td></tr>
+        <tr><td>Updated By</td><td>{{ optionalValue staffMember.lastName }}</td></tr>
+        <tr><td>Prison name</td><td>{{ getPrisonName prisonCode }}</td></tr>
+    </table>
+{{/.}}


### PR DESCRIPTION
Fix defect in template version logic: 

The service previously only ever checked the service API hash against the **latest** registered template version hash. 

This caused requests to fail if a `PENDING` template was registered but the service API was still returning the `PUBLISHED` template version. In this case the service **should** accept either the latest published version OR the latest pending version.

The first time the `PENDING` template value is returned the SAR service updates this template version from PENDING to PUBLISHED and the previous published version will no longer be accepted.